### PR TITLE
fix: create configPath if it doesn't exist

### DIFF
--- a/cmd/go-sbot/main.go
+++ b/cmd/go-sbot/main.go
@@ -158,6 +158,11 @@ func applyConfigValues() {
 	if isFlagPassed("repo") {
 		configPath = repoDir
 	}
+	if err := os.Mkdir(configPath, 0700); err != nil {
+		if !os.IsExist(err) {
+			panic(err)
+		}
+	}
 	if filepath.Ext(configPath) != ".toml" {
 		configPath = filepath.Join(configPath, "config.toml")
 	}


### PR DESCRIPTION
If `~/.go-ssb` or `-repo <PATH>` doesn't exist, create it. 

Uses `0700` as default perms for more secure perms.

Closes https://github.com/ssbc/go-ssb/issues/144.

Before this patch:
```
❯ ./go-sbot -repo .foo
level=info t=58.149µs event="read config" msg="no config detected" path=.foo/config.toml
t=662.008µs event=panic location=main-panic panicLog=panics/main-panic3547787861 err="open .foo/running-config.json: no such file or directory"
```

After this patch:
```
❯ ./go-sbot -repo .foo   
level=info t=237.161µs event="read config" msg="no config detected" path=.foo/config.toml
level=info t=601.684µs event="write running-config.json" msg="active config and env vars have been persisted" path=.foo/running-config.json
level=info t=661.383µs event="set repo" path=/home/decentral1se/work/ssbc/go-ssb/.foo
t=1.222104ms starting=metrics addr=localhost:6078
2022/07/22 15:51:46 saved identity @ofN1qhaiCOnykNb6wVxWmR4VsKAPPRHAaBnKeCrXV3E=.ed25519 to .foo/secret
level=info t=84.937319ms event="waiting for indexes to catch up"
level=info t=85.098756ms event="repo open" feeds=0 msgs=0
level=info t=85.156693ms event=serving ID="@ofN1qhaiCOnykNb6wVxWmR4VsKAPPRHAaBnKeCrXV3E=.ed25519" addr=:8008 version=snapshot build=
```

/cc @cblgh 