### PR TITLE
fix: ignore binaries when built in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 
 # ignore built binaries
 cmd/go-sbot/go-sbot
+go-sbot
 cmd/sbotcli/sbotcli
+sbotcli
 
 # ignore crash/test data
 **/testrun/


### PR DESCRIPTION
I run `go build ./cmd/go-sbot` as I run the editor from the repo root also.

This PR ignores those binaries also.