### PR TITLE
fix: pass deref'd value

### DIFF
--- a/private/manager_groups.go
+++ b/private/manager_groups.go
@@ -127,7 +127,7 @@ func (mgr *Manager) deriveCloakedAndStoreNewKey(k keys.Recipient) (refs.MessageR
 		return emptyMsgRef, err
 	}
 
-	rootAsTFK, err := tfk.Encode(k.Metadata.GroupRoot)
+	rootAsTFK, err := tfk.Encode(*k.Metadata.GroupRoot)
 	if err != nil {
 		return emptyMsgRef, err
 	}


### PR DESCRIPTION
While waiting on https://github.com/ssbc/go-ssb-refs/issues/1, this fixes the test for now.

Maybe closes https://github.com/ssbc/go-ssb/issues/157 (maybe there are other failing tests...).