### PR TITLE
fix: follow new types for CreateSubFeed/Get

### DIFF
--- a/message/legacy/metafeed_announce_test.go
+++ b/message/legacy/metafeed_announce_test.go
@@ -51,7 +51,7 @@ func TestPublishMetafeedAnnounce(t *testing.T) {
 	)
 	r.NoError(err)
 
-	subfeed, err := bot.MetaFeeds.CreateSubFeed("testfeed", refs.RefAlgoFeedSSB1)
+	subfeed, err := bot.MetaFeeds.CreateSubFeed(bot.KeyPair.ID(), "testfeed", refs.RefAlgoFeedSSB1)
 	r.NoError(err)
 
 	ma := legacy.NewMetafeedAnnounce(bot.KeyPair.ID(), subfeed)
@@ -62,7 +62,7 @@ func TestPublishMetafeedAnnounce(t *testing.T) {
 	ref, err := bot.MetaFeeds.Publish(subfeed, signedMsg)
 	r.NoError(err)
 
-	msg, err := bot.Get(ref)
+	msg, err := bot.Get(ref.Key())
 	r.NoError(err)
 	t.Log("content:", string(msg.ContentBytes()))
 


### PR DESCRIPTION
```
        go.cryptoscope.co/ssb/message/legacy
# go.cryptoscope.co/ssb/message/legacy_test [go.cryptoscope.co/ssb/message/legacy.test]
message/legacy/metafeed_announce_test.go:54:58: not enough arguments in call to bot.MetaFeeds.CreateSubFeed
	have (string, refs.RefAlgo)
	want (refs.FeedRef, string, refs.RefAlgo, ...map[string]string)
message/legacy/metafeed_announce_test.go:65:22: cannot use ref (variable of type refs.Message) as type refs.MessageRef in argument to bot.Get
FAIL	go.cryptoscope.co/ssb/message/legacy [build failed]
FAIL
```