### PR TITLE
feat: badger lite & limited replication backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ go install ./cmd/go-sbot
 go install ./cmd/sbotcli
 ```
 
-## Testing 
+## Testing
 
 Once you have configured your environment set up to build the binaries, you can also run the tests. We have unit tests for most of the modules, most importantly `message`, `blobstore` and the replication plugins (`gossip` and `blobs`). There are also interoperability tests with the nodejs implementation (this requires recent versions of [node and npm](http://nodejs.org)).
 
@@ -348,6 +348,12 @@ The error can look like this:
 ```
 badger failed to open: Mmap value log file. Path=C:\\some\\where\\.ssb-go\\indexes\\contacts\\db\\000000.vlog. Error=MapViewOfFile: Not enough memory resources are available to process this command.
 ```
+
+### `go-ssb` is too memory hungry?
+
+Building with `-tags nommio` can be useful.
+
+Try also experimenting with `-numPeer` / `-numRepl` if you're using legacy gossip replication. This will limit the amount of replication that can happen concurrently. See [`#124`](https://github.com/ssbc/go-ssb/issues/124) for more details.
 
 ## Stack links
 

--- a/README.md
+++ b/README.md
@@ -339,19 +339,15 @@ go-sbot &
 sbotcli connect "net:some.ho.st:8008~shs:SomeActuallyValidPubKey="
 ```
 
-### Startup error / no mmio
-
-The badger key-value database defaults to loading some of it's files using [memory-mapped i/o](https://en.wikipedia.org/wiki/Memory-mapped_I/O). If this turns out to be a problem on your target platform, you can use `go build -tags nommio` when building to fall back to standard files, which can be a bit slower but should still be fully functional.
-
-The error can look like this:
-
-```
-badger failed to open: Mmap value log file. Path=C:\\some\\where\\.ssb-go\\indexes\\contacts\\db\\000000.vlog. Error=MapViewOfFile: Not enough memory resources are available to process this command.
-```
-
 ### `go-ssb` is too memory hungry?
 
-Building with `-tags nommio` can be useful.
+Try building with the `-tags lite` build tag:
+
+```
+go build -tags lite ./cmd/go-sbot
+```
+
+It uses a lightweight BadgerDB configuration that [Planetary](https://github.com/planetary-social/ssb/blob/a76247b9e67a2792113f33840d1f15bbb1467d93/repo/badger_ios.go) have been running.
 
 Try also experimenting with `-numPeer` / `-numRepl` if you're using legacy gossip replication. This will limit the amount of replication that can happen concurrently. See [`#124`](https://github.com/ssbc/go-ssb/issues/124) for more details.
 

--- a/cmd/go-sbot/config.go
+++ b/cmd/go-sbot/config.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"bytes"
-	"github.com/ssbc/go-ssb/internal/testutils"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/komkom/toml"
-	"go.mindeco.de/log/level"
 	loglib "log"
 	"os"
 	"strconv"
+
+	"github.com/komkom/toml"
+	"github.com/ssbc/go-ssb/internal/testutils"
+	"go.mindeco.de/log/level"
 )
 
 type ConfigBool bool
@@ -32,6 +33,9 @@ type SbotConfig struct {
 	EnableEBT           ConfigBool `json:"enable-ebt"`
 	EnableFirewall      ConfigBool `json:"promisc"`
 	RepairFSBeforeStart ConfigBool `json:"repair"`
+
+	NumPeer uint `json:"numPeer,omitempty"`
+	NumRepl uint `json:"numRepl,omitempty"`
 
 	presence map[string]interface{}
 }
@@ -162,6 +166,18 @@ func ReadEnvironmentVariables(config *SbotConfig) {
 	if val := os.Getenv("SSB_CAP_HMAC_KEY"); val != "" {
 		config.Hmac = val
 		config.presence["hmac"] = true
+	}
+
+	if val := os.Getenv("SSB_NUM_PEER"); val != "" {
+		numPeer, err := strconv.Atoi(val)
+		check(err, "parse numPeer from environment variable")
+		config.NumPeer = uint(numPeer)
+	}
+
+	if val := os.Getenv("SSB_NUM_REPL"); val != "" {
+		numRepl, err := strconv.Atoi(val)
+		check(err, "parse numRepl from environment variable")
+		config.NumRepl = uint(numRepl)
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,7 +32,7 @@ as blanks `""` will be ignored.
 
 **Note** the keys of the config file are the same as the names of the equivalent flags which
 can be used when invoking `go-sbot`. For example, if you wanted to set the `hops` to 2 and the
-default ssb-go location to somewhere else using only flags, that would look like: 
+default ssb-go location to somewhere else using only flags, that would look like:
 
 ```
 ./go-sbot -hops 2 -repo /var/scuttlebutt
@@ -42,35 +42,40 @@ default ssb-go location to somewhere else using only flags, that would look like
 
 ```toml
 # Where to put the log and indexes
-repo = '.ssb-go' 
+repo = '.ssb-go'
 # Where to write debug output: NOTE, this is relative to "repo" atm
-debugdir = '' 
+debugdir = ''
 
 # Secret-handshake app-key (or compatible alt-key)
-shscap = "1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=" 
+shscap = "1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s="
 # If set, sign with hmac hash of msg instead of plain message object using this key
-hmac = "" 
+hmac = ""
 # How many hops to fetch (1: friends, 2: friends of friends); note that a nodejs hops value needs to be decreased by one in go-sbot
 # e.g. go-sbot hops of 1 <=> ssb-js hops of 2
-hops = 1 
+hops = 1
+
+# how many feeds can be replicated with one peer connection using legacy gossip (shouldn't be higher than numRepl)
+numPeer = 5
+# how many feeds can be replicated concurrently using legacy gossip
+numRepl = 10
 
 # Address to listen on
-lis = ":8008" 
+lis = ":8008"
 # Address to listen on for ssb websocket connections
-wslis = ":8989" 
+wslis = ":8989"
 # Address to listen on for metrics and pprof HTTP server
-debuglis = "localhost:6078" 
+debuglis = "localhost:6078"
 
 # Enable sending local UDP broadcasts
-localadv = false 
+localadv = false
 # Enable connecting to incoming UDP broadcasts
-localdiscov = false 
+localdiscov = false
 # Enable syncing by using epidemic-broadcast-trees (EBT)
-enable-ebt = false 
+enable-ebt = false
 # Bypass graph auth and fetch remote's feed, useful for pubs that are restoring their data from peers. Caveats abound, however.
-promisc = false 
+promisc = false
 # Disable the UNIX socket RPC interface
-nounixsock = false 
+nounixsock = false
 ```
 
 ## Environment Variables
@@ -90,7 +95,7 @@ SSB_CAP_SHS_KEY=""
 SSB_CAP_HMAC_KEY=""
 SSB_HOPS=2
 
-SSB_MUXRPC_ADDRESS=":8008" 
+SSB_MUXRPC_ADDRESS=":8008"
 SSB_WS_ADDRESS=":8989"
 SSB_PROMETHEUS_ADDRESS="localhost:6078"  // aka debug metrics
 
@@ -99,6 +104,10 @@ SSB_EBT_ENABLED=no
 SSB_CONN_FIREWALL_ENABLED=yes // equivalent with --promisc
 SSB_CONN_DISCOVERY_UDP_ENABLED=no
 SSB_CONN_BROADCAST_UDP_ENABLED=no
+
+// limited replication
+SSB_NUM_PEER=5
+SSB_NUM_REPL=10
 
 // go-ssb specific (for peachpub compat purposes)
 GO_SSB_REPAIR_FS=no

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,3 +7,18 @@ stores as of October 2022. You can however use `sbotcli` to query muxrpc
 endpoints with clients like Patchwork.
 
 See [`#80`](https://github.com/ssbc/go-ssb/issues/80) for more.
+
+## What platforms does `go-ssb` support?
+
+We've seen reports of butts running `go-ssb` successfully on:
+
+- GNU/Linux
+- Mac OS X
+- Rasperry Pi 3/4
+- Orange Pi Zero
+- iOS
+- Android
+
+Go [supports several other OS/arch](https://go.dev/doc/install/source#environment) possibilities.
+
+Please let us know if you manage to run `go-ssb` on a new platform that is not listed above.

--- a/plugins/gossip/fetch.go
+++ b/plugins/gossip/fetch.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"time"
 
 	"github.com/ssbc/go-muxrpc/v2"
@@ -17,66 +18,101 @@ import (
 	"go.mindeco.de/log/level"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/ssbc/go-ssb"
+	refs "github.com/ssbc/go-ssb-refs"
 	"github.com/ssbc/go-ssb/internal/neterr"
 	"github.com/ssbc/go-ssb/message"
-	refs "github.com/ssbc/go-ssb-refs"
 )
 
 func (h *LegacyGossip) FetchAll(
 	ctx context.Context,
-	e muxrpc.Endpoint,
-	set *ssb.StrFeedSet,
+	edp muxrpc.Endpoint,
 	withLive bool,
 ) error {
-	lst, err := set.List()
+	set := h.WantList.ReplicationList()
+
+	feeds, err := set.List()
 	if err != nil {
 		return err
 	}
 
-	// TODO: warning unbound parallellism ahead.
-	// since we don't have a way yet to handoff a feed
-	// all feeds will be stuck in the pool.
-	//
-	// this is very bad if you have a lot of them.
-	//
-	// ebt will make this better
-	// we need some kind of pull feed manager, similar to Blobs
-	// which we can ask for which feeds aren't in transit,
-	// due for a (probabilistic) update
-	// and manage live feeds more granularly across open connections
+	rand.Shuffle(len(feeds), func(i, j int) {
+		feeds[i], feeds[j] = feeds[j], feeds[i]
+	})
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	fetchGroup, ctx := errgroup.WithContext(ctx)
 
-	for _, r := range lst {
-		fetchGroup.Go(h.workFeed(ctx, e, r, withLive))
-	}
+	feedCh := make(chan refs.FeedRef)
 
-	err = fetchGroup.Wait()
-	return err
+	errGroup := h.startWorkers(ctx, feedCh, edp)
+
+	go func() {
+		defer close(feedCh)
+
+		for _, feed := range feeds {
+			select {
+			case <-ctx.Done():
+				return
+			case feedCh <- feed:
+				continue
+			}
+		}
+	}()
+
+	return errGroup.Wait()
 }
 
-func (h *LegacyGossip) workFeed(ctx context.Context, edp muxrpc.Endpoint, ref refs.FeedRef, withLive bool) func() error {
-	return func() error {
-		err := h.fetchFeed(ctx, ref, edp, time.Now(), withLive)
-		var callErr *muxrpc.CallError
-		var noSuchMethodErr muxrpc.ErrNoSuchMethod
-		if muxrpc.IsSinkClosed(err) ||
-			errors.As(err, &noSuchMethodErr) ||
-			errors.As(err, &callErr) ||
-			errors.Is(err, context.Canceled) ||
-			errors.Is(err, muxrpc.ErrSessionTerminated) ||
-			neterr.IsConnBrokenErr(err) {
-			return err
-		} else if err != nil {
-			// just logging the error assuming forked feed for instance
-			level.Warn(h.Info).Log("event", "skipped updating of stored feed", "err", err, "fr", ref.ShortSigil())
-		}
+func (h *LegacyGossip) startWorkers(ctx context.Context, feedCh <-chan refs.FeedRef, edp muxrpc.Endpoint) *errgroup.Group {
+	errGroup, ctx := errgroup.WithContext(ctx)
 
-		return nil
+	for i := 0; i < h.numberOfConcurrentReplicationsPerPeer; i++ {
+		errGroup.Go(
+			func() error {
+				for {
+					select {
+					case feed, ok := <-feedCh:
+						if !ok {
+							return nil
+						}
+
+						if err := h.workFeed(ctx, edp, feed, false); err != nil {
+							return err
+						}
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			},
+		)
 	}
+
+	return errGroup
+}
+
+func (h *LegacyGossip) workFeed(ctx context.Context, edp muxrpc.Endpoint, ref refs.FeedRef, withLive bool) error {
+	select {
+	case <-h.tokenPool.GetToken():
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	defer h.tokenPool.ReturnToken()
+
+	err := h.fetchFeed(ctx, ref, edp, time.Now(), withLive)
+	var callErr *muxrpc.CallError
+	var noSuchMethodErr muxrpc.ErrNoSuchMethod
+	if muxrpc.IsSinkClosed(err) ||
+		errors.As(err, &noSuchMethodErr) ||
+		errors.As(err, &callErr) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, muxrpc.ErrSessionTerminated) ||
+		neterr.IsConnBrokenErr(err) {
+		return err
+	} else if err != nil {
+		// just logging the error assuming forked feed for instance
+		level.Warn(h.Info).Log("event", "skipped updating of stored feed", "err", err, "fr", ref.ShortSigil())
+	}
+
+	return nil
 }
 
 // fetchFeed requests the feed fr from endpoint e into the repo of the handler
@@ -166,4 +202,27 @@ func (h *LegacyGossip) fetchFeed(
 	}
 
 	return nil
+}
+
+type TokenPool struct {
+	ch chan struct{}
+}
+
+func NewTokenPool(n int) *TokenPool {
+	ch := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		ch <- struct{}{}
+	}
+
+	return &TokenPool{
+		ch: ch,
+	}
+}
+
+func (p *TokenPool) GetToken() <-chan struct{} {
+	return p.ch
+}
+
+func (p *TokenPool) ReturnToken() {
+	p.ch <- struct{}{}
 }

--- a/repo/badger_default.go
+++ b/repo/badger_default.go
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+//go:build !nommio
 // +build !nommio
 
 package repo
@@ -14,5 +15,4 @@ func badgerOpts(dbPath string) badger.Options {
 	opts := badger.DefaultOptions(dbPath)
 	opts.Logger = nil
 	return opts
-
 }

--- a/repo/badger_default.go
+++ b/repo/badger_default.go
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-//go:build !nommio
-// +build !nommio
+//go:build !lite
+// +build !lite
 
 package repo
 

--- a/repo/badger_ios.go
+++ b/repo/badger_ios.go
@@ -13,6 +13,13 @@ import (
 
 func badgerOpts(dbPath string) badger.Options {
 	return badger.DefaultOptions(dbPath).
-		WithValueLogFileSize(1 << 21).
+		WithMemTableSize(1 << 25).
+		WithValueLogFileSize(1 << 25).
+		WithNumMemtables(10).
+		WithNumLevelZeroTables(3).
+		WithNumLevelZeroTablesStall(7).
+		WithNumCompactors(2).
+		WithIndexCacheSize(1 << 27).
+		WithBlockCacheSize(1 << 27).
 		WithLogger(nil)
 }

--- a/repo/badger_lite.go
+++ b/repo/badger_lite.go
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-//go:build nommio
-// +build nommio
+//go:build lite
+// +build lite
 
 package repo
 

--- a/sbot/options.go
+++ b/sbot/options.go
@@ -427,3 +427,23 @@ func LateOption(o Option) Option {
 		return nil
 	}
 }
+
+// WithNumberOfConcurrentReplicationsPerPeer specifies how many feeds can be
+// replicated at the same time using one peer connection. This shouldn't be
+// higher than WithNumberOfConcurrentReplications, setting it higher will be
+// ineffective. Only legacy gossip is supported.
+func WithNumberOfConcurrentReplicationsPerPeer(n uint) Option {
+	return func(s *Sbot) error {
+		s.numberOfConcurrentReplicationsPerPeer = n
+		return nil
+	}
+}
+
+// WithNumberOfConcurrentReplications specifies how many feeds can be
+// replicated at the same time. Only legacy gossip is supported.
+func WithNumberOfConcurrentReplications(n uint) Option {
+	return func(s *Sbot) error {
+		s.numberOfConcurrentReplications = n
+		return nil
+	}
+}


### PR DESCRIPTION
For https://github.com/ssbc/go-ssb/issues/124 testing @mycognosist @interfect @luandro @vielmetti @ahdinosaur  :construction: 

Now that https://github.com/ssbc/go-ssb/pull/176 landed, the new BadgerDB data store is incompatible with previous versions afaiu. So, please back up your `~/.ssb-go` before testing if you still have one! Best start from a fresh `~/.ssb-go` / keypair while testing, I guess. There may be some way to migrate it forward, can take a look if you need that.

There could be more to tweak in the new BadgerDB configuration, we can consult https://github.com/dgraph-io/badger/blob/main/docs/content/get-started/index.md#memory-usage & https://pkg.go.dev/github.com/dgraph-io/badger/v3#Options.

This PR adds a new lightweight BadgerDB config that @mplorentz / @boreq @ Planetary have been running and backports (slightly re-worked) several commits that @boreq implemented which allow us to limit the amount of concurrent replication that is allowed. This means we should be able to limit `go-sbot` from OOM'ing.

There are still some bugs with replication but let's put those aside for the moment... we just want the thing to run for the moment :sweat_smile: 

You can test this with the following commands:

```
git clone https://github.com/decentral1se/ssb
cd ssb
git checkout lite-fixes
go build -tags lite -v ./cmd/go-sbot
go build -v ./cmd/sbotcli
```

You'll notice two new flags on `go-sbot` (should also be available in the config):

```
  -numPeer uint
    	how many feeds can be replicated with one peer connection (shouldn't be higher than numRepl) (default 5)
  -numRepl uint
    	how many feeds can be replicated concurrently (default 10)
```

I followed the defaults of Planetary who are targetting iOS, you may need to tweak it!

Good luck and do let me know :woman_dancing: 