### PR TITLE
docs: moar faq & updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,20 +307,6 @@ If you see the above error, make sure your project has the following replace dir
 replace golang.org/x/crypto => github.com/cryptix/golang_x_crypto v0.0.0-20200303113948-2939d6771b24
 ```
 
-### compilation error regarding Badger
-
-This should only happen if you are not using _Go modules_ way of building and the `vendor/` folder isn't used to build the SSB code. Badger pushed an API change to master. We still depend on v1.5.4 as there is only a candidate release version of the new API yet.
-
-```
-# go.cryptoscope.co/librarian/badger
-./index.go:53:13: assignment mismatch: 2 variables but 1 values
-./index.go:53:26: not enough arguments in call to item.Value
-	have ()
-	want (func([]byte) error)
-```
-
-Either use the _Go Module_ way of building the project, which uses the pinned version specified by the `go.mod` file or check out the specific version of badger in your `$GOPATH`.
-
 ### Startup error / illegal JSON value
 
 We currently use a [very rough state file](https://github.com/keks/persist) to keep track of which messages are indexed already (multilogs and contact graph). When the server crashes while it is being rewritten, this file can get corrupted. We have a fsck-like tool in mind to rebuild the indicies from the static log but it's not done yet.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 
 [![GoDoc](https://godoc.org/github.com/ssbc/go-ssb?status.svg)](https://godoc.org/github.com/ssbc/go-ssb) [![Go Report Card](https://goreportcard.com/badge/github.com/ssbc/go-ssb)](https://goreportcard.com/report/github.com/ssbc/go-ssb) ![Github Actions](https://github.com/ssbc/go-ssb/actions/workflows/go.yml/badge.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![REUSE status](https://api.reuse.software/badge/github.com/ssbc/go-ssb)](https://api.reuse.software/info/github.com/ssbc/go-ssb)
 
-> WARNING: Project is still in alpha, backwards incompatible changes will be made. We suggest vendoring for a stable experience.
+> **WARNING**: Project is still in alpha, backwards incompatible changes will be made.
 
 A full-stack implementation of [secure-scuttlebutt](https://www.scuttlebutt.nz) using the [Go](https://golang.org) programming language.
 
@@ -101,7 +101,7 @@ The problem with this (for Go and others) is removing the `signature` field from
 
 What you are free to input is the `content` object, the rest is filled in for you. The author is determined by the keypair used by go-sbot. Multiple identities are supported through the API.
 
-### over muxrpc
+### Over muxrpc
 
 go-sbot also exposes the same async [publish](https://scuttlebot.io/apis/scuttlebot/ssb.html#publish-async) method that ssb-server has. So you can also use it with ssb-client!
 
@@ -171,7 +171,7 @@ func check(err error) {
 }
 ```
 
-### sbotcli
+### `sbotcli`
 
 Has some commands to publish frequently used messages like `post`, `vote` and `contact`:
 

--- a/README.md
+++ b/README.md
@@ -193,11 +193,9 @@ cat some.json | sbotcli publish raw
 
 ## Building
 
-We are trying to adopt the new [Go Modules](https://github.com/golang/go/wiki/Modules) way of defining dependencies and therefore require at least Go version 1.11 to build with the `go.mod` file definitions. (Building with earlier versions is still possible, though. We keep an intact dependency tree in `vendor/`, populated by `go mod vendor`, which is picked up by default since Go 1.09.)
-
 There are two binary executable in this project that are useful right now, both located in the `cmd` folder. `go-sbot` is the database server, handling incoming connections and supplying replication to other peers. `sbotcli` is a command line interface to query feeds and instruct actions like _connect to X_. This also works against the JS implementation.
 
-If you _just_ want to build the server and play without contributing to the code (and are using a recent go version > 1.11), you can do this:
+If you _just_ want to build the server and play without contributing to the code (and are using a recent go version > 1.17), you can do this:
 
 ```bash
 # clone the repo

--- a/README.md
+++ b/README.md
@@ -210,28 +210,28 @@ go build -v -i
 sudo cp go-sbot /usr/local/bin
 ```
 
-If you want to hack on the other dependencies of the stack, we still advise using the classic Go way with a `$GOPATH`. This way you have all the code available to inspect and change. (Go modules get stored in a read-only cache. Replacing them needs a checkout on an individual basis.)
+If you want to hack on the other dependencies of the stack, you can use the `replace` statement.
 
-```bash
-# prepare workspace for all the go code
-export GOPATH=$HOME/proj/go-ssb
-mkdir -p $GOPATH
-# fetch project source and dependencies
-go get -v -u github.com/ssbc/go-ssb
-# change to the project directory
-cd $GOPATH/src/github.com/ssbc/go-ssb
-# build the binaries (will get saved to $GOPATH/bin)
-go install ./cmd/go-sbot
-go install ./cmd/sbotcli
+E.g. for hacking on a locally cloned copy of `go-muxrpc`, you'd do:
+
+```diff
+diff --git a/go.mod b/go.mod
+index c4d475f..51c2757 100644
+--- a/go.mod
++++ b/go.mod
+@@ -6,6 +6,8 @@ module github.com/ssbc/go-ssb
+
++replace github.com/ssbc/go-muxrpc/v2 => ./../go-muxrpc
++
 ```
+
+Which points the new build of `go-sbot`/`sbotcli` to use your local copy of `go-muxrpc`.
 
 ## Testing
 
 Once you have configured your environment set up to build the binaries, you can also run the tests. We have unit tests for most of the modules, most importantly `message`, `blobstore` and the replication plugins (`gossip` and `blobs`). There are also interoperability tests with the nodejs implementation (this requires recent versions of [node and npm](http://nodejs.org)).
 
 ```bash
-$ cd $GOPATH/src/github.com/ssbc/go-ssb
-
 $ go test -v ./message
 2019/01/08 12:21:55 loaded 236 messages from testdata.zip
 === RUN   TestPreserveOrder
@@ -269,12 +269,13 @@ ok  	github.com/ssbc/go-ssb/plugins/gossip	0.667s
 
 (Sometimes the gossip test blocks indefinitely. This is a bug in go-muxrpcs closing behavior. See the _Known bugs_ section for more information.)
 
-
 To run the interop tests you need to install the dependencies first and then run the tests. Diagnosing a failure might require adding the `-v` flag to get the stderr output from the nodejs process.
 
 ```bash
-$ cd $GOPATH/src/github.com/ssbc/go-ssb/tests
-$ npm ci
+$ cd message/legacy && npm ci
+$ go test -v
+$ cd -
+$ cd tests && npm ci
 $ go test -v
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,9 @@
 # FAQ
 
+## Is `go-ssb` production ready?
+
+No, not yet. It is still in the alpha stages and backwards incompatible changes will be made.
+
 ## Is `go-ssb` compatible with other data stores (ssb-db, ssb-db2)?
 
 No, you can't use `go-ssb` API bindings to read / write other ssb client data
@@ -7,6 +11,10 @@ stores as of October 2022. You can however use `sbotcli` to query muxrpc
 endpoints with clients like Patchwork.
 
 See [`#80`](https://github.com/ssbc/go-ssb/issues/80) for more.
+
+## Can `go-ssb` replicate with Manyverse?
+
+Not reliably, as EBT replication still has some issues (see below). What you can do though is replicate with other Patchwork users. And Patchwork can replicate with Manyverse. So you just need one Patchwork user in your network and gossip should work.
 
 ## What platforms does `go-ssb` support?
 
@@ -23,3 +31,11 @@ We've seen reports of butts running `go-ssb` successfully on:
 Go [supports several other OS/arch](https://go.dev/doc/install/source#environment) possibilities.
 
 Please let us know if you manage to run `go-ssb` on a new platform that is not listed above.
+
+## Does EBT (`-enable-ebt`) replication work?
+
+We've seen several reports (e.g. `%lmBRs0eSQP9JLTuVgVEipf4a9Ke5uSHZq0xt8UIzQSs=.sha256`) that it does not work reliably in the current state (November 2022). There are a number of [EBT related fixes living on the Planetary fork](https://github.com/planetary-social/ssb/tree/fork) which which might help. Those patches were / are being run by Planetary and others [have tested them](https://github.com/ssbc/go-ssb/pull/180#issuecomment-1295784977), YMMV!
+
+## What is the realtionship between `go-ssb` & `scuttlego`?
+
+It's still a bit fuzzy but pulling some notes from the previous discussions: `scuttlego` is a new effort to build "an embeddable sdk for building lots of ssb apps, not just for planetary" which is being developed by Go hackers @ [Planetary](https://planetary.social). It is still in the early stages of development. For more background information, see `%AfPRFA+lc8bu95GQ04q43prH65jDukkSn8cBIg6Lbyc=.sha256` and [`github.com/planetary-social/scuttlego`](https://github.com/planetary-social/scuttlego).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,12 +10,14 @@ See [`#80`](https://github.com/ssbc/go-ssb/issues/80) for more.
 
 ## What platforms does `go-ssb` support?
 
+> **WARNING**: we've seen reports of data loss issues on 32 bit architectures, e.g. some of the Orage Pi Zero earlier series and older Rasperry Pis. This is being investigated on [`go-ssb/#183`](https://github.com/ssbc/go-ssb/issues/183). We would recommend avoiding 32 bit architecture systems until this issue has been wrapped up.
+
 We've seen reports of butts running `go-ssb` successfully on:
 
 - GNU/Linux
 - Mac OS X
-- Rasperry Pi 3/4
-- Orange Pi Zero
+- Rasperry Pi 3/4 (amd64/arm64)
+- Orange Pi Zero (amd64/arm64)
 - iOS
 
 Go [supports several other OS/arch](https://go.dev/doc/install/source#environment) possibilities.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,7 +17,6 @@ We've seen reports of butts running `go-ssb` successfully on:
 - Rasperry Pi 3/4
 - Orange Pi Zero
 - iOS
-- Android
 
 Go [supports several other OS/arch](https://go.dev/doc/install/source#environment) possibilities.
 


### PR DESCRIPTION
@mycognosist 

Think this is basically everything I know at this point.

- [`README.md` rendered](https://github.com/decentral1se/ssb/blob/352ad46e7619ecb7bb8e18f073efccf9ef9a3c7b/README.md)
- [`FAQ.md` rendered](https://github.com/decentral1se/ssb/blob/352ad46e7619ecb7bb8e18f073efccf9ef9a3c7b/docs/faq.md)

Added `[ci skip]` to avoid wasting CI build cycles on this one.