### PR TITLE
fix: replies muxrpc call

### DIFF
--- a/cmd/sbotcli/streams.go
+++ b/cmd/sbotcli/streams.go
@@ -177,7 +177,7 @@ var repliesStreamCmd = &cli.Command{
 		}
 		targs.Name = ctx.String("tname")
 
-		src, err := client.Source(longctx, muxrpc.TypeJSON, muxrpc.Method{"tangles", "replies"}, targs)
+		src, err := client.Source(longctx, muxrpc.TypeJSON, muxrpc.Method{"tangles", "thread"}, targs)
 		if err != nil {
 			return fmt.Errorf("source stream call failed: %w", err)
 		}


### PR DESCRIPTION
Got renamed in 8b49ff543a2ef7a15a79050f21568eb6b847ce80 but `sbotcli` didn't get updated.

So you can do `./sbotcli replies "%bVCZHYhsQEdz/TNXPXuhHhbzL58ILktaiAVv4aQdjso=.sha256"` and get all the relevant messages connected with that root. This isn't quite "backlinks" level functionality afaiu but a client could make use of this output to sort by the various fields in the resulting JSON.

If I can further grok the cryptix notes below, another step would be exposing the `root: ...` indices... 

Deffo need this functionality for making client experiments...

`%tYzpHO2irGnJEKMomIoVFNzAI8FCAk+ILs07ufA6iDE=.sha256`

@mycognosist