### PR TITLE
fix: invite --uses parsing & invite accept

### DIFF
--- a/cmd/gossb-migrate-mf/migrate/migration.go
+++ b/cmd/gossb-migrate-mf/migrate/migration.go
@@ -25,6 +25,8 @@ import (
 	"github.com/ssbc/go-metafeed/metakeys"
 	"github.com/ssbc/go-metafeed/metamngmt"
 	"github.com/ssbc/go-ssb"
+	refs "github.com/ssbc/go-ssb-refs"
+	"github.com/ssbc/go-ssb-refs/tfk"
 	"github.com/ssbc/go-ssb/internal/mutil"
 	"github.com/ssbc/go-ssb/internal/slp"
 	"github.com/ssbc/go-ssb/internal/storedrefs"
@@ -34,8 +36,6 @@ import (
 	"github.com/ssbc/go-ssb/query"
 	"github.com/ssbc/go-ssb/repo"
 	"github.com/ssbc/go-ssb/sbot"
-	refs "github.com/ssbc/go-ssb-refs"
-	"github.com/ssbc/go-ssb-refs/tfk"
 )
 
 func migrationAlreadyRun(ssbdir string) bool {
@@ -189,6 +189,7 @@ func ew(header string) func(msg string, err ...error) error {
 }
 
 const sentinelName = ".metafeeds-upgraded"
+
 // Creates an empty file, signaling that the migration has run successfully. go-sbot will look for this file to
 // determine if it is to start up in metafeedsEnabled mode or not—and this tool looks for the file before continuing to
 // run the migration (should the sentinel not exist yet).

--- a/invite/legacy.go
+++ b/invite/legacy.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/ssbc/go-muxrpc/v2"
 	"github.com/ssbc/go-ssb"
-	"github.com/ssbc/go-ssb/client"
 	refs "github.com/ssbc/go-ssb-refs"
+	"github.com/ssbc/go-ssb/client"
 )
 
 // Redeem takes an invite token and a long term key.

--- a/tests/invite_legacy_test.go
+++ b/tests/invite_legacy_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/ssbc/go-muxrpc/v2"
 	"github.com/ssbc/go-netwrap"
 	refs "github.com/ssbc/go-ssb-refs"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ssbc/go-ssb/client"
 	"github.com/ssbc/go-ssb/internal/testutils"


### PR DESCRIPTION
@staltz @mycognosist 

Closes https://github.com/ssbc/go-ssb/issues/181

- fixes the parsing of `--uses n` on the `invite create ...` on `sbotcli`
- adds `invite accept <invite> <feed-id>` to `sbotcli`