### PR TITLE
build: wire up goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ sbotcli
 
 # 'make $platform' output
 release
+dist
 
 # ignore vim swap files
 **/.*.sw[op]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2022 The Go-SSB Authors
+# SPDX-License-Identifier: MIT
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: go-ssb
+    dir: cmd/go-sbot
+    binary: go-ssb
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+
+  - id: go-ssb-lite
+    dir: cmd/go-sbot
+    binary: go-ssb-lite
+    flags:
+      - -tags=lite
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+
+  - id: sbotcli
+    dir: cmd/sbotcli
+    binary: sbotcli
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+
+archives:
+  - id: go-ssb
+    format: binary
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
See https://github.com/ssbc/go-ssb/issues/188. Experimental binaries built with this config are available on:

> https://vvvvvvaria.org/~decentral1se/ssb/go-ssb

Will be doing some testing with them before merging this. Let me know if you're testing also :heart: 

Generated with `goreleaser release --snapshot`.
