### PR TITLE
Fix directories for build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can install the project using Golang's [install command](https://golang.org/
 
 ```bash
 git clone https://github.com/ssbc/go-ssb
-cd ssb
+cd go-ssb
 go install ./cmd/go-sbot
 go install ./cmd/sbotcli
 ```
@@ -201,7 +201,7 @@ If you _just_ want to build the server and play without contributing to the code
 # clone the repo
 git clone https://github.com/ssbc/go-ssb
 # go into the servers folder
-cd ssb/cmd/go-sbot
+cd go-ssb/cmd/go-sbot
 # build the binary (also fetches pinned dependencies)
 go build -v -i
 # test the executable works by printing it's help listing

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,7 +19,7 @@ The precedence order goes as follows:
 * default flag values are the final fallback, if the corresponding config value or environment variable has not been set
 
 ## Configuration file
-The default location for the config file is `~/.go-ssb/config.toml`. The order of precedence
+The default location for the config file is `~/.ssb-go/config.toml`. The order of precedence
 when it comes to loading a config file is as follows:
 
 * 1. Environment variable `$SSB_CONFIG_FILE` or flag `--config` are used first
@@ -124,6 +124,6 @@ be they from the configuration file or from environment variables, then these ar
 particular file called `running-config.json`.
 
 This file is located in relation to the configuration directory specified by the --config flag,
-and defaults to `~/.go-ssb/running-config.json`.
+and defaults to `~/.ssb-go/running-config.json`.
 
 **Note**: overrides from --flag options will not be represented in `running-config.json`.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -21,7 +21,7 @@ to confirm go is installed.
 On your server:
 ```
 git clone https://github.com/ssbc/go-ssb
-cd ssb
+cd go-ssb
 go install ./cmd/go-sbot
 go install ./cmd/sbotcli
 ```


### PR DESCRIPTION
Build process documentation assumes the `git clone` will clone into a directory called "ssb".  It actually defaults to "go-ssb".  This fixes the documentation.