### PR TITLE
Improve sbotcli documentation

### DIFF
--- a/cmd/sbotcli/aliases.go
+++ b/cmd/sbotcli/aliases.go
@@ -20,6 +20,7 @@ import (
 
 var aliasCmd = &cli.Command{
 	Name: "alias",
+	Usage: "Register and revoke user aliases (for use with SSB Room servers)",
 	Subcommands: []*cli.Command{
 		aliasRegisterCmd,
 		aliasRevokeCmd,

--- a/cmd/sbotcli/blobs.go
+++ b/cmd/sbotcli/blobs.go
@@ -23,6 +23,7 @@ var blobsStore ssb.BlobStore
 
 var blobsCmd = &cli.Command{
 	Name: "blobs",
+	Usage: "Add a blob to the local store or call MUXRPC methods: `has`, `get` and `wants`",
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "path", Value: "", Usage: "specify the path to the blobs folder of the sbot you want to query"},
 	},

--- a/cmd/sbotcli/friends.go
+++ b/cmd/sbotcli/friends.go
@@ -18,6 +18,7 @@ import (
 
 var friendsCmd = &cli.Command{
 	Name: "friends",
+	Usage: "Retrieve information about the social graph (follows, blocks, hops)",
 	Subcommands: []*cli.Command{
 		friendsIsFollowingCmd,
 		friendsBlocksCmd,

--- a/cmd/sbotcli/main.go
+++ b/cmd/sbotcli/main.go
@@ -51,8 +51,8 @@ var (
 
 	log kitlog.Logger
 
-	keyFileFlag  = cli.StringFlag{Name: "key,k", Value: "unset"}
-	unixSockFlag = cli.StringFlag{Name: "unixsock", Usage: "if set, unix socket is used instead of tcp"}
+	keyFileFlag  = cli.StringFlag{Name: "key,k", Usage: "Secret key file", Value: "unset"}
+	unixSockFlag = cli.StringFlag{Name: "unixsock", Usage: "If set, Unix socket is used instead of TCP"}
 )
 
 func init() {
@@ -71,14 +71,14 @@ var app = cli.App{
 	Version: "alpha4",
 
 	Flags: []cli.Flag{
-		&cli.StringFlag{Name: "shscap", Value: "1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=", Usage: "shs key"},
-		&cli.StringFlag{Name: "addr", Value: "localhost:8008", Usage: "tcp address of the sbot to connect to (or listen on)"},
-		&cli.StringFlag{Name: "remoteKey", Value: "", Usage: "the remote pubkey you are connecting to (by default the local key)"},
+		&cli.StringFlag{Name: "shscap", Value: "1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=", Usage: "SHS key"},
+		&cli.StringFlag{Name: "addr", Value: "localhost:8008", Usage: "TCP address of the sbot to connect to (or listen on)"},
+		&cli.StringFlag{Name: "remoteKey", Value: "", Usage: "The remote pubkey you are connecting to (by default the local key)"},
 		&keyFileFlag,
 		&unixSockFlag,
-		&cli.BoolFlag{Name: "verbose,vv", Usage: "print muxrpc packets"},
+		&cli.BoolFlag{Name: "verbose,vv", Usage: "Print MUXRPC packets"},
 
-		&cli.StringFlag{Name: "timeout", Value: "45s", Usage: "pass a duration (like 3s or 5m) after which it times out, empty string to disable"},
+		&cli.StringFlag{Name: "timeout", Value: "45s", Usage: "Pass a duration (like 3s or 5m) after which it times out (empty string to disable)"},
 	},
 
 	Before: initClient,
@@ -211,7 +211,7 @@ func newTCPClient(ctx *cli.Context) (*ssbClient.Client, error) {
 
 var callCmd = &cli.Command{
 	Name:  "call",
-	Usage: "make an dump* async call",
+	Usage: "Make an async call",
 	UsageText: `SUPPORTS:
 * whoami
 * latestSequence
@@ -269,7 +269,7 @@ CAVEAT: only one argument...
 
 var sourceCmd = &cli.Command{
 	Name:  "source",
-	Usage: "make an simple source call",
+	Usage: "Make a source call",
 
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "id", Value: ""},
@@ -311,7 +311,7 @@ var sourceCmd = &cli.Command{
 
 var getSubsetCmd = &cli.Command{
 	Name:  "subset",
-	Usage: "invoke the partialReplication.getSubset muxrpc",
+	Usage: "Fetch subsets of messages from the log",
 
 	// define cli flags
 	Flags: []cli.Flag{
@@ -369,7 +369,7 @@ var getSubsetCmd = &cli.Command{
 
 var getCmd = &cli.Command{
 	Name:  "get",
-	Usage: "get a single message from the database by key (%...)",
+	Usage: "Get a single message from the local database by key (%...)",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "private"},
 		&cli.StringFlag{Name: "format", Value: "json"},
@@ -415,7 +415,7 @@ var getCmd = &cli.Command{
 
 var connectCmd = &cli.Command{
 	Name:  "connect",
-	Usage: "connect to a remote peer",
+	Usage: "Connect to a remote peer",
 	Action: func(ctx *cli.Context) error {
 		to := ctx.Args().Get(0)
 		if to == "" {
@@ -451,6 +451,7 @@ var connectCmd = &cli.Command{
 
 var blockCmd = &cli.Command{
 	Name: "block",
+	Usage: "Block a peer by specifying their public key (@...)",
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)
 		if err != nil {
@@ -482,7 +483,7 @@ var blockCmd = &cli.Command{
 
 var groupsCmd = &cli.Command{
 	Name:  "groups",
-	Usage: "group managment (create, invite, publishTo, etc.)",
+	Usage: "Manage groups (create, invite, publishTo, join)",
 	Subcommands: []*cli.Command{
 		groupsCreateCmd,
 		groupsInviteCmd,
@@ -600,6 +601,7 @@ var groupsJoinCmd = &cli.Command{
 
 var inviteCmds = &cli.Command{
 	Name: "invite",
+	Usage: "Create and accept invite codes",
 	Subcommands: []*cli.Command{
 		inviteCreateCmd,
 		inviteAcceptCmd,

--- a/cmd/sbotcli/publish.go
+++ b/cmd/sbotcli/publish.go
@@ -17,7 +17,7 @@ import (
 
 var publishCmd = &cli.Command{
 	Name:  "publish",
-	Usage: "p",
+	Usage: "Publish a message by type (raw, post, about, contact and vote)",
 	Subcommands: []*cli.Command{
 		publishRawCmd,
 		publishPostCmd,

--- a/cmd/sbotcli/streams.go
+++ b/cmd/sbotcli/streams.go
@@ -57,6 +57,7 @@ func getStreamArgs(ctx *cli.Context) message.CreateHistArgs {
 
 var historyStreamCmd = &cli.Command{
 	Name:  "hist",
+	Usage: "Fetch all messages authored by the local keypair / author",
 	Flags: append(streamFlags, &cli.StringFlag{Name: "id"}, &cli.BoolFlag{Name: "asJSON"}),
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)
@@ -91,6 +92,7 @@ var historyStreamCmd = &cli.Command{
 
 var logStreamCmd = &cli.Command{
 	Name:  "log",
+	Usage: "Fetch all messages from the local database (ordered by received time)",
 	Flags: streamFlags,
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)
@@ -113,6 +115,7 @@ var logStreamCmd = &cli.Command{
 
 var sortedStreamCmd = &cli.Command{
 	Name:  "sorted",
+	Usage: "Fetch all messages from the local database (ordered by message timestamps)",
 	Flags: streamFlags,
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)
@@ -135,6 +138,7 @@ var sortedStreamCmd = &cli.Command{
 
 var typeStreamCmd = &cli.Command{
 	Name:  "bytype",
+	Usage: "Fetch all messages from the local database matching the given type (e.g. post, vote, about etc.)",
 	Flags: streamFlags,
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)
@@ -160,6 +164,7 @@ var typeStreamCmd = &cli.Command{
 
 var repliesStreamCmd = &cli.Command{
 	Name:  "replies",
+	Usage: "Fetch all replies to the given root message (%...)",
 	Flags: append(streamFlags, &cli.StringFlag{Name: "tname", Usage: "tangle name (v2)"}),
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)
@@ -191,6 +196,7 @@ var repliesStreamCmd = &cli.Command{
 
 var replicateUptoCmd = &cli.Command{
 	Name:  "upto",
+	Usage: "Return a list of all public keys in the log, along with the latest sequence number for each",
 	Flags: streamFlags,
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)


### PR DESCRIPTION
Begins to address https://github.com/ssbc/go-ssb/issues/217

For now I have simply added capitalised usage descriptions for each top-level command and global option.

Here's how it's looking:

```shell
NAME:
   ./sbotcli - client for controlling Cryptoscope's SSB server

USAGE:
   ./sbotcli [global options] command [command options] [arguments...]

VERSION:
   alpha4

COMMANDS:
   alias    Register and revoke user aliases (for use with SSB Room servers)
   blobs    Add a blob to the local store or call MUXRPC methods: `has`, `get` and `wants`
   block    Block a peer by specifying their public key (@...)
   friends  Retrieve information about the social graph (follows, blocks, hops)
   get      Get a single message from the local database by key (%...)
   subset   Fetch subsets of messages from the log
   invite   Create and accept invite codes
   log      Fetch all messages from the local database (ordered by received time)
   sorted   Fetch all messages from the local database (ordered by message timestamps)
   bytype   Fetch all messages from the local database matching the given type (e.g. post, vote, about etc.)
   hist     Fetch all messages authored by the local keypair / author
   upto     Return a list of all public keys in the log, along with the latest sequence number for each
   replies  Fetch all replies to the given root message (%...)
   call     Make an async call
   source   Make a source call
   connect  Connect to a remote peer
   publish  Publish a message by type (raw, post, about, contact and vote)
   groups   Manage groups (create, invite, publishTo, join)
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --shscap value     SHS key (default: "1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=")
   --addr value       TCP address of the sbot to connect to (or listen on) (default: "localhost:8008")
   --remoteKey value  The remote pubkey you are connecting to (by default the local key)
   --key value        Secret key file (default: "/home/cordyceps/.ssb-go/secret")
   --unixsock value   If set, Unix socket is used instead of TCP (default: "/home/cordyceps/.ssb-go/socket")
   --verbose          Print MUXRPC packets (default: false)
   --timeout value    Pass a duration (like 3s or 5m) after which it times out (empty string to disable) (default: "45s")
   --help, -h         show help (default: false)
   --version, -v      print the version (default: false)
```

@decentral1se 

I welcome any feedback / changes to wording! Not sure if I've hit the right balance of clarity and verbosity.
I also want to capitalise the usage sentences for `help` and `version`.