### PR TITLE
Add description fields with example to each command

### DIFF
--- a/cmd/sbotcli/blobs.go
+++ b/cmd/sbotcli/blobs.go
@@ -25,7 +25,7 @@ var blobsCmd = &cli.Command{
 	Name:  "blobs",
 	Usage: "Add a blob to the local store or call MUXRPC methods: `has`, `get` and `wants`",
 	Flags: []cli.Flag{
-		&cli.StringFlag{Name: "path", Value: "", Usage: "specify the path to the blobs folder of the sbot you want to query"},
+		&cli.StringFlag{Name: "path", Value: "", Usage: "Specify the path to the blobs folder of the sbot you want to query"},
 	},
 	Before: func(ctx *cli.Context) error {
 		var blobsDir = ctx.String("path")
@@ -57,9 +57,15 @@ var blobsCmd = &cli.Command{
 }
 
 var blobsHasCmd = &cli.Command{
-	Name:      "has",
-	Usage:     "Check if a blob is in the repo",
-	ArgsUsage: "<&...sha256>",
+	Name:        "has",
+	Usage:       "Check if a blob is in the local blobstore.",
+	ArgsUsage:   "<&...sha256>",
+	Description: `Check if a blob is in the local blobstore.
+
+Example:
+
+    sbotcli blobs has "&hB2vsBGwqPAfkBQ5IQGIrLfHXzytmExYC3iJ6FC08F8=.sha256"`,
+
 	Action: func(ctx *cli.Context) error {
 		ref := ctx.Args().Get(0)
 		if ref == "" {
@@ -95,9 +101,20 @@ var blobsHasCmd = &cli.Command{
 }
 
 var blobsWantCmd = &cli.Command{
-	Name:      "want",
-	Usage:     "Try to get a blob from other peers",
-	ArgsUsage: "<&...sha256>",
+	Name:        "want",
+	Usage:       "Try to get a blob from other peers.",
+	ArgsUsage:   "<&...sha256>",
+	Description: `Try to get a blob from other peers.
+
+Adds the blob reference to a list of blobs being requested by the local sbot.
+This list of desired blobs is then shared with connected peers who then
+replicate the blob(s) if they have them. This means the requested blob(s) will
+likely not be received straight away (ie. there may be replication delays).
+
+Example:
+
+    sbotcli blobs has "&hB2vsBGwqPAfkBQ5IQGIrLfHXzytmExYC3iJ6FC08F8=.sha256"`,
+
 	Action: func(ctx *cli.Context) error {
 		ref := ctx.Args().Get(0)
 		if ref == "" {
@@ -117,9 +134,17 @@ var blobsWantCmd = &cli.Command{
 }
 
 var blobsAddCmd = &cli.Command{
-	Name:      "add",
-	Usage:     "Add a file to the store (pass - to open stdin)",
-	ArgsUsage: "[<filename> | - <stdin>]",
+	Name:        "add",
+	Usage:       "Add a file to the blobstore (pass - to open stdin).",
+	ArgsUsage:   "[<filename> | - <stdin>]",
+	Description: `Add a file to the blobstore (pass - to open stdin).
+
+A blob reference will be returned (<&...sha256>) if the file is added successfully.
+
+Example:
+
+    cat /home/glyph/Pictures/2022/cabin_computer_setup.jpeg | sbotcli blobs add -`,
+
 	Action: func(ctx *cli.Context) error {
 		if blobsStore == nil {
 			return fmt.Errorf("no blobstore use 'blobs --path $repo/blobs add -' for now")
@@ -147,11 +172,19 @@ var blobsAddCmd = &cli.Command{
 }
 
 var blobsGetCmd = &cli.Command{
-	Name:      "get",
-	Usage:     "Prints the first argument to stdout",
-	ArgsUsage: "<&...sha256>",
+	Name:        "get",
+	Usage:       "Streams the contents of the file",
+	ArgsUsage:   "<&...sha256>",
+	Description: `Streams the contents of the file.
+
+Contents are streamed to stdout by default. An alternative destination can be
+defined using the 'out' flag.
+
+Example:
+
+    sbotcli blobs get "&grLTZFapgHZHXRYh1zgz2bTuDelottGZSfogKauo/fk=.sha256" > blob_file`,
 	Flags: []cli.Flag{
-		&cli.StringFlag{Name: "out", Value: "-", Usage: "where to? (stdout by default)"},
+		&cli.StringFlag{Name: "out", Value: "-", Usage: "Where to? (stdout by default)"},
 	},
 	Action: func(ctx *cli.Context) error {
 		if blobsStore == nil {
@@ -167,7 +200,7 @@ var blobsGetCmd = &cli.Command{
 		}
 		reader, err := blobsStore.Get(blobsRef)
 		if err != nil {
-			return fmt.Errorf("blobs: failed to parse argument ref: %w", err)
+			return fmt.Errorf("blobs: failed to retrieve blob from store: %w", err)
 		}
 
 		var out io.Writer

--- a/cmd/sbotcli/friends.go
+++ b/cmd/sbotcli/friends.go
@@ -27,9 +27,15 @@ var friendsCmd = &cli.Command{
 }
 
 var friendsIsFollowingCmd = &cli.Command{
-	Name:      "isFollowing",
-	Usage:     "Check if a feed is friends with another (follows back)",
-	ArgsUsage: "<@...ed25519> <@...ed25519>",
+	Name:        "isFollowing",
+	Usage:       "Check if a feed is friends with another (follows back)",
+	ArgsUsage:   "<@...ed25519> <@...ed25519>",
+	Description: `Check if a feed is friends with another (follows back).
+
+Example:
+
+sbotcli friends isFollowing @HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519 @mfY4X9Gob0w2oVfFv+CpX56PfL0GZ2RNQkc51SJlMvc=.ed25519`,
+
 	Action: func(ctx *cli.Context) error {
 		src := ctx.Args().Get(0)
 		if src == "" {
@@ -72,11 +78,21 @@ var friendsIsFollowingCmd = &cli.Command{
 	},
 }
 var friendsHopsCmd = &cli.Command{
-	Name:      "hops",
-	Usage:     "Find out how many hops a feed ref is",
-	ArgsUsage: "<@...ed25519>",
+	Name:        "hops",
+	Usage:       "List all peers within the hops range of the given feed ID",
+	ArgsUsage:   "<@...ed25519>",
+	Description: `List all peers within the hops range of the given feed ID.
+
+When the <dist> flag is set to 0, the peers in the returned list represent the
+friends (mutual follows) of the given feed ID. Setting <dist> to 1 includes
+friends-of-friends in the output. The default value is 2. Be aware that this
+may return a long list!
+
+Example:
+
+    sbotcli friends hops --dist 0 @HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519`,
 	Flags: []cli.Flag{
-		&cli.UintFlag{Name: "dist", Value: 2, Usage: "non-remote repo allows for access withut involving a bot"},
+		&cli.UintFlag{Name: "dist", Value: 2, Usage: "Hops range"},
 	},
 	Action: func(ctx *cli.Context) error {
 		var arg friends.HopsArgs
@@ -109,9 +125,15 @@ var friendsHopsCmd = &cli.Command{
 }
 
 var friendsBlocksCmd = &cli.Command{
-	Name:      "blocks",
-	Usage:     "List blocks for a feed ref",
-	ArgsUsage: "<@...ed25519>",
+	Name:        "blocks",
+	Usage:       "List all peers blocked by the given feed ID",
+	ArgsUsage:   "<@...ed25519>",
+	Description: `List all peers blocked by the given feed ID.
+
+Example:
+
+    sbotcli friends blocks @fGWzOR/FXU3Acbn4P65CpMewJIynFyqocvfLAyJdDno=.ed25519`,
+
 	Action: func(ctx *cli.Context) error {
 		var args = []interface{}{}
 

--- a/cmd/sbotcli/main.go
+++ b/cmd/sbotcli/main.go
@@ -317,14 +317,15 @@ var sourceCmd = &cli.Command{
 }
 
 var getSubsetCmd = &cli.Command{
-	Name:  "subset",
-	Usage: "Fetch subsets of messages from the log.",
-	Description: `
-An example:
+	Name:        "subset",
+	Usage:       "Fetch subsets of messages from the log.",
+	ArgsUsage:   "<json>",
+	Description: `Fetch subsets of messages from the log.
 
-    sbotcli subset '{"op":"type", "string": "post"}'
+Example:
+
+    sbotcli subset --limit 3 '{"op":"type", "string": "post"}'
 `,
-	ArgsUsage: "<json>",
 	// define cli flags
 	Flags: []cli.Flag{
 		&cli.IntFlag{Name: "limit", Value: -1},
@@ -383,6 +384,11 @@ var getCmd = &cli.Command{
 	Name:      "get",
 	Usage:     "Get a single message from the local database by key (%...)",
 	ArgsUsage: "<%...sha256>",
+	Description: `Get a single message from the local database by key (%...).
+
+Example:
+
+    sbotcli get %Dj/W4PYYZUWj/iWlyVuOg8pgv4b+BwP0qOF5OpD+o4I=.sha256`,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "private"},
 		&cli.StringFlag{Name: "format", Value: "json"},
@@ -427,19 +433,18 @@ var getCmd = &cli.Command{
 }
 
 var connectCmd = &cli.Command{
-	Name:  "connect",
-	Usage: "Connect to a remote peer.",
-	Description: `
-A multiserver address looks like this:
+	Name:        "connect",
+	Usage:       "Connect to a remote peer.",
+	ArgsUsage:   "<multiserver address>",
+	Description: `Connect to a remote peer.
 
-    net:$HOST:$PORT~shs:$BASE64_OF_SSB_ID
+Example:
 
-More info here:
+    sbotcli connect "net:192.168.8.136:8008~shs:HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk="
 
-    https://github.com/ssbc/multiserver#address-format
-`,
-	ArgsUsage: "<addr>",
-	Action: func(ctx *cli.Context) error {
+See https://github.com/ssbc/multiserver#address-format for more information about multiserver addresses.`,
+
+  Action: func(ctx *cli.Context) error {
 		to := ctx.Args().Get(0)
 		if to == "" {
 			return errors.New("connect: multiserv addr argument can't be empty")
@@ -473,9 +478,15 @@ More info here:
 }
 
 var blockCmd = &cli.Command{
-	Name:      "block",
-	Usage:     "Block a peer by specifying their public key (@...)",
-	ArgsUsage: "<@...ed25519>",
+	Name:        "block",
+	Usage:       "Block a peer by specifying their public key (@...)",
+	ArgsUsage:   "<@...ed25519>",
+	Description: `Block a peer by specifying their public key (@...).
+
+Example:
+
+    sbotcli block @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519`,
+
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)
 		if err != nil {
@@ -636,8 +647,13 @@ var inviteCmds = &cli.Command{
 }
 
 var inviteCreateCmd = &cli.Command{
-	Name:  "create",
-	Usage: "Register and return an invite for somebody else to accept",
+	Name:        "create",
+	Usage:       "Register and return an invite for somebody else to accept",
+	Description: `Register and return an invite for somebody else to accept.
+
+Example:
+
+    sbotcli invite create --uses 7`,
 	Flags: []cli.Flag{
 		&cli.UintFlag{Name: "uses", Value: 1, Usage: "How many times an invite can be used"},
 	},

--- a/cmd/sbotcli/main.go
+++ b/cmd/sbotcli/main.go
@@ -71,8 +71,7 @@ var app = cli.App{
 	Description: `
 Please note, global options must be placed before sub-commands, e.g.
 
-    sbotcli --key <@...ed25519> <cmd> <args>
-`,
+    sbotcli --key <@...ed25519> <cmd> <args>`,
 	Version: "alpha4",
 
 	Flags: []cli.Flag{
@@ -215,24 +214,25 @@ func newTCPClient(ctx *cli.Context) (*ssbClient.Client, error) {
 }
 
 var callCmd = &cli.Command{
-	Name:  "call",
-	Usage: "Make an async call",
-	UsageText: `Supports common muxrpc async calls such as:
+	Name:        "call",
+	Usage:       "Make an async call",
+	ArgsUsage:   "<cmd> <arg>",
+	Description: `Make an async call.
 
-* whoami
-* latestSequence
-* getLatest
-* get
+Supports common muxrpc async calls such as:
+
 * blobs.(has|want|rm|wants)
+* get
+* getLatest
 * gossip.(peers|add|connect)
+* latestSequence
+* whoami
 
 Example:
 
     sbotcli call conn.connect "net:localhost:8008~shs:drNvbM6G1BSwklFzhKvRqeQZyHnxfkOKEbwPd3Fr3co="
 
-See https://scuttlebot.io/apis/scuttlebot/ssb.html for more.
-`,
-	ArgsUsage: "<cmd> <arg>",
+See https://scuttlebot.io/apis/scuttlebot/ssb.html for more.`,
 	Action: func(ctx *cli.Context) error {
 		cmd := ctx.Args().Get(0)
 		if cmd == "" {
@@ -276,9 +276,25 @@ See https://scuttlebot.io/apis/scuttlebot/ssb.html for more.
 }
 
 var sourceCmd = &cli.Command{
-	Name:      "source",
-	Usage:     "Make a source call",
-	ArgsUsage: "<cmd>",
+	Name:        "source",
+	Usage:       "Make a source call",
+	ArgsUsage:   "<cmd>",
+	Description: `Make a source call.
+
+Call any muxrpc method that returns a stream, as long as the method takes the
+form of a <command.subcommand>.
+
+Supports common muxrpc source calls such as:
+
+* blobs.(get|ls|createWants)
+* friends.(hops|blocks)
+* partialReplication.getSubset
+* replicate.upto
+
+Example:
+
+    sbotcli source replicate.upto`,
+
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "id", Value: ""},
 		// TODO: Slice of branches
@@ -434,7 +450,7 @@ Example:
 
 var connectCmd = &cli.Command{
 	Name:        "connect",
-	Usage:       "Connect to a remote peer.",
+	Usage:       "Connect to a remote peer",
 	ArgsUsage:   "<multiserver address>",
 	Description: `Connect to a remote peer.
 

--- a/cmd/sbotcli/main.go
+++ b/cmd/sbotcli/main.go
@@ -318,7 +318,7 @@ var sourceCmd = &cli.Command{
 
 var getSubsetCmd = &cli.Command{
 	Name:        "subset",
-	Usage:       "Fetch subsets of messages from the log.",
+	Usage:       "Fetch subsets of messages from the log",
 	ArgsUsage:   "<json>",
 	Description: `Fetch subsets of messages from the log.
 

--- a/cmd/sbotcli/publish.go
+++ b/cmd/sbotcli/publish.go
@@ -35,7 +35,7 @@ var publishRawCmd = &cli.Command{
 
 Example:
 
-echo '{"type":"post","text":"example"}' | sbotcli publish raw`,
+    echo '{"type":"post","text":"example"}' | sbotcli publish raw`,
   
 	// TODO: add private
 	Action: func(ctx *cli.Context) error {
@@ -73,7 +73,7 @@ var publishPostCmd = &cli.Command{
 
 Example:
 
-sbotcli publish post "Gophers create a network of tunnel systems that provide protection."`,
+    sbotcli publish post "Gophers create a network of tunnel systems that provide protection."`,
 
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "root", Value: "", Usage: "The key of the first message of the thread"},
@@ -132,7 +132,7 @@ var publishVoteCmd = &cli.Command{
 
 Example:
 
-sbotcli publish vote --value 1 %GOmisAlROznJEWJ/eht6tJWXgjFdQhbUKx4+/SeyoqI=.sha256`,
+    sbotcli publish vote --value 1 %GOmisAlROznJEWJ/eht6tJWXgjFdQhbUKx4+/SeyoqI=.sha256`,
 
 	Flags: []cli.Flag{
 		&cli.IntFlag{Name: "value", Usage: "Usually 1 (like) or 0 (unlike)"},
@@ -205,7 +205,7 @@ var publishAboutCmd = &cli.Command{
 
 Example:
 
-sbotcli publish about --name "glf" @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519`,
+    sbotcli publish about --name "glf" @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519`,
 
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "name", Usage: "The name to be assigned to the public key"},
@@ -259,15 +259,15 @@ var publishContactCmd = &cli.Command{
 
 Example (follow):
 
-sbotcli publish contact --following @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
+    sbotcli publish contact --following @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
 
 Example (unfollow):
 
-sbotcli publish contact @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
+    sbotcli publish contact @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
 
 Example (block):
 
-sbotcli publish contact --blocking @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
+    sbotcli publish contact --blocking @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
 
 Note that both fields (following and blocking) are set with each published contact message.
 This means that both the following and blocking fields can be updated with a single published message.`,

--- a/cmd/sbotcli/publish.go
+++ b/cmd/sbotcli/publish.go
@@ -28,9 +28,14 @@ var publishCmd = &cli.Command{
 }
 
 var publishRawCmd = &cli.Command{
-	Name:      "raw",
-	Usage:     "Read JSON from stdin and publish it as the content of a new message",
-  ArgsUsage: "<json>",
+	Name:        "raw",
+	Usage:       "Read JSON from stdin and publish it as the content of a new message",
+  ArgsUsage:   "<json>",
+	Description: `Read JSON from stdin and publish it as the content of a new message.
+
+Example:
+
+echo '{"type":"post","text":"example"}' | sbotcli publish raw`,
   
 	// TODO: add private
 	Action: func(ctx *cli.Context) error {
@@ -61,9 +66,15 @@ var publishRawCmd = &cli.Command{
 }
 
 var publishPostCmd = &cli.Command{
-	Name:      "post",
-	Usage:     "Publish a post (public or private)",
-	ArgsUsage: "<text>",
+	Name:        "post",
+	Usage:       "Publish a post (public or private)",
+	ArgsUsage:   "<text>",
+	Description: `Publish a post (public or private).
+
+Example:
+
+sbotcli publish post "Gophers create a network of tunnel systems that provide protection."`,
+
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "root", Value: "", Usage: "The key of the first message of the thread"},
 		// TODO: Slice of branches
@@ -114,9 +125,15 @@ var publishPostCmd = &cli.Command{
 }
 
 var publishVoteCmd = &cli.Command{
-	Name:      "vote",
-	Usage:     "Publish a vote or expression",
-	ArgsUsage: "<%...sha256>",
+	Name:        "vote",
+	Usage:       "Publish a vote or expression",
+	ArgsUsage:   "<%...sha256>",
+	Description: `Publish a vote or expression.
+
+Example:
+
+sbotcli publish vote --value 1 %GOmisAlROznJEWJ/eht6tJWXgjFdQhbUKx4+/SeyoqI=.sha256`,
+
 	Flags: []cli.Flag{
 		&cli.IntFlag{Name: "value", Usage: "Usually 1 (like) or 0 (unlike)"},
 		&cli.StringFlag{Name: "expression", Usage: "An expression made in response to a message (ie. 'dig', 'yup' or 'heart')"},
@@ -181,9 +198,15 @@ var publishVoteCmd = &cli.Command{
 }
 
 var publishAboutCmd = &cli.Command{
-	Name:      "about",
-	Usage:     "Publish an about message to define the name or image assigned to a public key",
-	ArgsUsage: "<@...ed25519>",
+	Name:        "about",
+	Usage:       "Publish an about message to define the name or image assigned to a public key",
+	ArgsUsage:   "<@...ed25519>",
+	Description: `Publish an about message to define the name or image assigned to a public key.
+
+Example:
+
+sbotcli publish about --name "glf" @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519`,
+
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "name", Usage: "The name to be assigned to the public key"},
 		&cli.StringFlag{Name: "image", Usage: "The image blob ref to be assigned to the public key"},
@@ -229,9 +252,26 @@ var publishAboutCmd = &cli.Command{
 }
 
 var publishContactCmd = &cli.Command{
-	Name:      "contact",
-	Usage:     "Publish a contact message (follow, unfollow, block, unblock)",
-	ArgsUsage: "<@...ed25519>",
+	Name:        "contact",
+	Usage:       "Publish a contact message (follow, unfollow, block, unblock)",
+	ArgsUsage:   "<@...ed25519>",
+	Description: `Publish a contact message (follow, unfollow, block, unblock).
+
+Example (follow):
+
+sbotcli publish contact --following @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
+
+Example (unfollow):
+
+sbotcli publish contact @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
+
+Example (block):
+
+sbotcli publish contact --blocking @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
+
+Note that both fields (following and blocking) are set with each published contact message.
+This means that both the following and blocking fields can be updated with a single published message.`,
+
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "following", Usage: "A boolean expression denoting the follow state"},
 		&cli.BoolFlag{Name: "blocking", Usage: "A boolean expression denoting the block state"},

--- a/cmd/sbotcli/streams.go
+++ b/cmd/sbotcli/streams.go
@@ -163,13 +163,17 @@ var typeStreamCmd = &cli.Command{
 }
 
 var repliesStreamCmd = &cli.Command{
-	Name:  "replies",
-	Usage: "Fetch all replies to the given root message (%...)",
-	Description: `
+	Name:        "replies",
+	Usage:       "Fetch all replies to the given root message (%...)",
+	ArgsUsage:   "<%...sha256>",
+	Description: `Fetch all replies to the given root message (%...).
+
 The --limt behaviour is root + n replies, i.e. the limit doesn't count the root
 message. This is different behaviour from the typical createHistoryStream call.
-`,
-	ArgsUsage: "<%...sha256>",
+
+Example:
+
+    sbotcli replies %6Jke7N/zqjxBlv3c6GgmQ96mGfpzszdhnKAnh2RnPR8=.sha256`,
 	Flags:     append(streamFlags, &cli.StringFlag{Name: "tname", Usage: "tangle name (v2)"}),
 	Action: func(ctx *cli.Context) error {
 		client, err := newClient(ctx)


### PR DESCRIPTION
Going through `sbotcli` and adding an example (in `Description`) to each command. 

- [x] publish
- [x] connect
- [x] subset
- [x] block
- [x] call
- [x] invite.create
- [x] blobs
- [x] friends 
- [x] replies
- [x] source

-----

Here's an example of the updated CLI output:

```text
NAME:
   ./sbotcli publish contact - Publish a contact message (follow, unfollow, block, unblock)

USAGE:
   ./sbotcli publish contact [command options] <@...ed25519>

DESCRIPTION:
   Publish a contact message (follow, unfollow, block, unblock).

   Example (follow):

       sbotcli publish contact --following @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519
     
   Example (unfollow):

       sbotcli publish contact @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519

   Example (block):

       sbotcli publish contact --blocking @r6Lzb9OT3/dlVYNDTABmsF+HWnhBsA1twZaobYhjVUY=.ed25519

   Note that both fields (following and blocking) are set with each published contact message.
   This means that both the following and blocking fields can be updated with a single published message.

OPTIONS:
   --following                      A boolean expression denoting the follow state (default: false)
   --blocking                       A boolean expression denoting the block state (default: false)
   --recps value [ --recps value ]  The public key(s) to whom this post will be published as a private message
   --help, -h                       show help (default: false)
```