### PR TITLE
fix: expose friends.blocks on manifest

### DIFF
--- a/sbot/manifest.go
+++ b/sbot/manifest.go
@@ -94,6 +94,7 @@ var manifestBlob manifestHandler = `
 
 	"friends": {
 	  "hops": "source",
+	  "blocks": "source",
 	  "isFollowing": "async",
 	  "isBlocking": "async"
 	},


### PR DESCRIPTION
Closes https://github.com/ssbc/go-ssb/issues/241.