### PR TITLE
Re-enable TestStatusCalls test

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -179,10 +179,6 @@ func TestLotsOfWhoami(t *testing.T) {
 func TestStatusCalls(t *testing.T) {
 	// defer leakcheck.Check(t)
 
-	if testutils.SkipOnCI(t) {
-		return
-	}
-
 	mkTCP := func(t *testing.T, opts ...sbot.Option) (*sbot.Sbot, mkClient) {
 		r := require.New(t)
 


### PR DESCRIPTION
I've run this test ~approximately 150~ 116 times, and it has not failed once.  I think whatever was making this fail must have been fixed.  This re-enables the test.

See #237 

Edit: corrected number of test runs.