### PR TITLE
test: skip TestReplicate & TestStartup

### DIFF
--- a/plugins/blobs/handler_test.go
+++ b/plugins/blobs/handler_test.go
@@ -14,19 +14,25 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/ssbc/go-muxrpc/v2"
 	"github.com/ssbc/go-ssb"
-	kitlog "go.mindeco.de/log"
 	refs "github.com/ssbc/go-ssb-refs"
+	"github.com/stretchr/testify/require"
+	kitlog "go.mindeco.de/log"
 
 	"github.com/ssbc/go-ssb/blobstore"
 	"github.com/ssbc/go-ssb/internal/broadcasts"
+	"github.com/ssbc/go-ssb/internal/testutils"
 	"github.com/ssbc/go-ssb/plugins/test"
 	"github.com/ssbc/go-ssb/repo"
 )
 
 func TestReplicate(t *testing.T) {
+	if testutils.SkipOnCI(t) {
+		// https://github.com/ssbc/go-ssb/issues/237
+		return
+	}
+
 	r := require.New(t)
 
 	srcRepo, srcPath := test.MakeEmptyPeer(t)

--- a/sbot/persistence_test.go
+++ b/sbot/persistence_test.go
@@ -13,14 +13,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/ssbc/margaret"
+	refs "github.com/ssbc/go-ssb-refs"
 	"github.com/ssbc/go-ssb/internal/leakcheck"
 	"github.com/ssbc/go-ssb/internal/storedrefs"
 	"github.com/ssbc/go-ssb/internal/testutils"
+	"github.com/ssbc/margaret"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mindeco.de/log"
-	refs "github.com/ssbc/go-ssb-refs"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/tests/local_fork_test.go
+++ b/tests/local_fork_test.go
@@ -1,17 +1,24 @@
 package tests
 
 import (
-	"testing"
 	"fmt"
-	"github.com/ssbc/margaret"
-	"github.com/ssbc/go-ssb/internal/storedrefs"
-	"github.com/ssbc/go-ssb/internal/mutil"
-	"github.com/ssbc/go-ssb/sbot"
-	"github.com/stretchr/testify/assert"
+	"testing"
+
 	refs "github.com/ssbc/go-ssb-refs"
+	"github.com/ssbc/go-ssb/internal/mutil"
+	"github.com/ssbc/go-ssb/internal/storedrefs"
+	"github.com/ssbc/go-ssb/internal/testutils"
+	"github.com/ssbc/go-ssb/sbot"
+	"github.com/ssbc/margaret"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestStartup (t *testing.T) {
+func TestStartup(t *testing.T) {
+	if testutils.SkipOnCI(t) {
+		// https://github.com/ssbc/go-ssb/issues/237
+		return
+	}
+
 	a := assert.New(t)
 	var err error
 	session := newSession(t, nil, nil)


### PR DESCRIPTION
Skip more failing tests as we work towards Fixing Them All via https://github.com/ssbc/go-ssb/issues/237.