### PR TITLE
Fix TestMigrate

### DIFF
--- a/cmd/gossb-migrate-mf/migrate/migrate_test.go
+++ b/cmd/gossb-migrate-mf/migrate/migrate_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ssbc/go-metafeed/metakeys"
 	refs "github.com/ssbc/go-ssb-refs"
-	"github.com/ssbc/go-ssb/internal/testutils"
 	"github.com/ssbc/go-ssb/sbot"
 	"github.com/stretchr/testify/require"
 )
@@ -41,11 +40,6 @@ func TestMigrationSentinel(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	if testutils.SkipOnCI(t) {
-		// https://github.com/ssbc/go-ssb/pull/167
-		return
-	}
-
 	/* setup start */
 	var err error
 	r := require.New(t)

--- a/plugins/gossip/feed_manager.go
+++ b/plugins/gossip/feed_manager.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"sync"
+	"strings"
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/ssbc/go-luigi"
@@ -104,7 +105,7 @@ func (m *FeedManager) serveLiveFeeds() {
 	}
 
 	err = luigi.Pump(m.rootCtx, luigi.FuncSink(m.pour), src)
-	if err != nil && err != ssb.ErrShuttingDown && err != context.Canceled {
+	if err != nil && err != ssb.ErrShuttingDown && err != context.Canceled && !strings.HasSuffix(err.Error(), "file already closed") {
 		err = fmt.Errorf("error while serving live feed: %w", err)
 		panic(err)
 	}


### PR DESCRIPTION
Fixes the `TestMigrate` test by detecting the error condition of a closed log and not erroring out at the live feed layer.  Ran successfully 238 times.

Fixes #257 

See also #237 