### PR TITLE
Re-enable TestSpec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ endif
 
 .PHONY: test
 test:
+	test -d private/box2/spec || git clone https://github.com/ssbc/envelope-spec private/box2/spec
 	$(foreach pkg, $(PKGS), echo -en "\n        $(pkg)\r"; LIBRARIAN_WRITEALL=0 go test $(TESTFLAGS) $(pkg) || exit 1;)
+	rm -rf private/box2/spec
 
 .PHONY: racetest
 racetest:

--- a/private/box2/spec_test.go
+++ b/private/box2/spec_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ssbc/go-ssb/internal/testutils"
 )
 
 func seq(start, end int) []byte {
@@ -26,10 +25,6 @@ func seq(start, end int) []byte {
 }
 
 func TestSpec(t *testing.T) {
-	if testutils.SkipOnCI(t) {
-		return
-	}
-
 	dir, err := os.Open(filepath.Join("spec", "vectors"))
 	if !assert.NoError(t, err, "open vectors dir") {
 		t.Log("suggestion: run 'git clone https://github.com/ssbc/envelope-spec spec'")


### PR DESCRIPTION
Doesn't actually appear to be broken, as long as you have `envelope-spec` downloaded like the test says.  Hoping the CI system knows how to do that.

Fixes #275 

See also #237 