### PR TITLE
Fix idxInSync, WaitUntilIndexesAreSynced, and TestNames

### DIFF
--- a/sbot/indexes.go
+++ b/sbot/indexes.go
@@ -199,7 +199,18 @@ func (s *Sbot) serveIndexFrom(name string, snk librarian.SinkIndex, msgs margare
 		s.indexStates[name] = "live"
 		s.indexStateMu.Unlock()
 
-		err = luigi.Pump(s.rootCtx, snk, src)
+		startWaiting := func() {
+		}
+		doneWaiting := func() {
+		}
+		startProcessing := func() {
+			s.idxInSync.Add(1)
+		}
+		doneProcessing := func() {
+			s.idxInSync.Done()
+		}
+
+		err = luigi.PumpWithStatus(s.rootCtx, snk, src, startWaiting, doneWaiting, startProcessing, doneProcessing)
 		if errors.Is(err, ssb.ErrShuttingDown) || errors.Is(err, context.Canceled) {
 			return nil
 		}

--- a/sbot/names_test.go
+++ b/sbot/names_test.go
@@ -18,16 +18,10 @@ import (
 	refs "github.com/ssbc/go-ssb-refs"
 	"github.com/ssbc/go-ssb/client"
 	"github.com/ssbc/go-ssb/internal/leakcheck"
-	"github.com/ssbc/go-ssb/internal/testutils"
 	"github.com/ssbc/go-ssb/repo"
 )
 
 func TestNames(t *testing.T) {
-	if testutils.SkipOnCI(t) {
-		// https://github.com/ssbc/go-ssb/pull/170
-		return
-	}
-
 	if os.Getenv("LIBRARIAN_WRITEALL") != "0" {
 		t.Fatal("please 'export LIBRARIAN_WRITEALL=0' for this test to pass")
 		// TODO: expose index flushing

--- a/sbot/names_test.go
+++ b/sbot/names_test.go
@@ -100,7 +100,8 @@ func TestNames(t *testing.T) {
 
 	checkLogSeq(mainbot.ReceiveLog, len(intros)-1) // got all the messages
 
-	// TODO: flush indexes
+	// flush indexes
+	mainbot.WaitUntilIndexesAreSynced()
 
 	c, err := client.NewUnix(filepath.Join(tRepoPath, "socket"))
 	r.NoError(err)


### PR DESCRIPTION
Requires [https://github.com/ssbc/go-luigi/pull/4](https://github.com/ssbc/go-luigi/pull/4), so be sure to add:

```
replace github.com/ssbc/go-luigi => ./../go-luigi
```

...or something like it to `go.mod` if that pull request hasn't yet been merged.

This fixes #251 and #250 by fixing `idxInSync`, `WaitUntilIndexesAreSynced()`, and `TestNames()`.  I ran `TestNames` over 500 times with zero failures with this in place.