### PR TITLE
Add "are indexes in sync" query

### DIFF
--- a/sbot/new.go
+++ b/sbot/new.go
@@ -85,6 +85,7 @@ type Sbot struct {
 	closers   multicloser.MultiCloser
 	idxDone   errgroup.Group
 	idxInSync sync.WaitGroup
+	idxNumSyncing int64
 
 	closed   bool
 	closedMu sync.Mutex


### PR DESCRIPTION
Based on #301 

This adds a function to sbot which allows for querying whether or not the indexes are all up-to-date at the present time.  This could be used for:

- Making sure that publishing during indexing doesn't fork your feed (see #292, #293)
- Status indicator in a UI layer above sbot
- Providing some kind of feedback to a user that if they choose to publish, it will not actually be published until after the indexes finish, depending on how #293 is implemented