### PR TITLE
Fix multiple index concurrency issues

### DIFF
--- a/message/publish_test.go
+++ b/message/publish_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,17 +18,11 @@ import (
 	"github.com/ssbc/go-ssb"
 	refs "github.com/ssbc/go-ssb-refs"
 	"github.com/ssbc/go-ssb/internal/asynctesting"
-	"github.com/ssbc/go-ssb/internal/testutils"
 	"github.com/ssbc/go-ssb/multilogs"
 	"github.com/ssbc/go-ssb/repo"
 )
 
 func TestSignMessages(t *testing.T) {
-	if testutils.SkipOnCI(t) {
-		// https://github.com/ssbc/go-ssb/pull/170
-		return
-	}
-
 	tctx := context.TODO()
 	r := require.New(t)
 	a := assert.New(t)
@@ -79,6 +74,11 @@ func TestSignMessages(t *testing.T) {
 		},
 	}
 	for i, msg := range tmsgs {
+		// delay for a bit to allow the indexes to catch up
+		// to be reliable, this has to be done between each publish
+		// TODO: find a way to wait for indexes for this isolated test like we do for sbot
+		time.Sleep(100 * time.Millisecond)
+
 		newSeq, err := w.Append(msg)
 		r.NoError(err, "failed to pour test message %d", i)
 		r.EqualValues(i, newSeq, "advanced")

--- a/sbot/identities.go
+++ b/sbot/identities.go
@@ -22,6 +22,7 @@ func (sbot *Sbot) PublishAs(nick string, val interface{}) (refs.Message, error) 
 
 	var pubopts = []message.PublishOption{
 		message.UseNowTimestamps(true),
+		message.UseWaitForIndexesCallback(sbot.WaitUntilIndexesAreSynced),
 	}
 	if sbot.signHMACsecret != nil { // all feeds use the same settings right now
 		pubopts = append(pubopts, message.SetHMACKey(sbot.signHMACsecret))

--- a/sbot/new.go
+++ b/sbot/new.go
@@ -325,6 +325,7 @@ func New(fopts ...Option) (*Sbot, error) {
 	// publish
 	var pubopts = []message.PublishOption{
 		message.UseNowTimestamps(true),
+		message.UseWaitForIndexesCallback(s.WaitUntilIndexesAreSynced),
 	}
 	if s.signHMACsecret != nil {
 		pubopts = append(pubopts, message.SetHMACKey(s.signHMACsecret))


### PR DESCRIPTION
Fixes #293, #292, #289 (ran over 1000 times with no FAILs) and should also fix #250.

So, there's a lot to unpack here:

1. Publishing messages now waits for indexes to finish.  I'd much rather we had some way to query Margaret outside of the indexes and use that so we didn't hold up the caller, but I have not found any way to do that.  This at least fixes a lot of the problems and allows us to move forward with stabilizing things at the cost of convenience for the caller.
2. Indexing now holds the `WaitGroup` for a short time after each message.  This is a theoretically unnecessary delay, but the end effect of this should be to delay publishing of new messages (not appending, because those rely on previous sequence numbers) by about 100 milliseconds.  However, this fixes the problem of the index wait prematurely terminating and allowing other processes to proceed before the indexes are actually caught up.  This if theoretically unnecessary because if we had a way to query the Luigi pumps to see if there was anything left in the source queue we could use that more directly to determine whether we need to continue waiting.  Unfortunately, I did not find a way to do that or even a way to patch it into Luigi without major restructuring of Luigi.  So this is the best solution I could come up with which should have the same effect and can be patched out later because it's still fully encapsulated within `sbot`s indexes system.  This, I'm pretty sure, is why we got that one stray `TestNames` failure in #250.  It actually makes a lot of sense now that I've had a chance to chew on it for a while.
3. `TestSignMessages` doesn't use `sbot`.  It has a completely separate system for indexes.  And that other system doesn't have a mechanism to wait for indexes to catch up.  So, to make it so the test is at least being used and is usefully testing the functionality it's trying to test, I've added some short delays to allow indexes to catch up.  I ran this test over 1000 times without any FAILs, so it should be fixed now.