### PR TITLE
Better sync

### DIFF
--- a/graph/builder.go
+++ b/graph/builder.go
@@ -84,6 +84,11 @@ func NewBuilder(log log.Logger, db *badger.DB, hmacSecret *[32]byte) *BadgerBuil
 
 		hmacSecret: hmacSecret,
 	}
+
+	// make sure we initialize the waitgroup so we have an opportunity to index
+	b.indexSyncStart()
+	defer b.indexSyncDone()
+
 	return b
 }
 

--- a/graph/builder_indexing.go
+++ b/graph/builder_indexing.go
@@ -152,6 +152,8 @@ func (b *BadgerBuilder) updateContacts(ctx context.Context, seq int64, val inter
 }
 
 func (b *BadgerBuilder) OpenContactsIndex() (librarian.SeqSetterIndex, librarian.SinkIndex) {
+	b.indexSyncStart()
+	defer b.indexSyncDone()
 	if b.idxSinkContacts == nil {
 		b.idxSinkContacts = librarian.NewSinkIndex(b.updateContacts, b.idx)
 	}

--- a/graph/people_test.go
+++ b/graph/people_test.go
@@ -19,6 +19,7 @@ import (
 	refs "github.com/ssbc/go-ssb-refs"
 	"github.com/ssbc/go-ssb/internal/storedrefs"
 	"github.com/ssbc/go-ssb/internal/testutils"
+	"github.com/ssbc/go-ssb/multilogs"
 )
 
 type PeopleOp interface {
@@ -260,6 +261,9 @@ func (tc PeopleTestCase) run(mk func(t *testing.T) testStore) func(t *testing.T)
 			err := op.Op(&state)
 			r.NoError(err, "error performing operation(%d) of %v type %T: %s", i, op, op)
 		}
+
+		// wait for the multilogs to catch up
+		multilogs.WaitUntilUserFeedIndexIsSynced()
 
 		// punch in nicks
 		g, err := state.store.gbuilder.Build()

--- a/graph/people_test.go
+++ b/graph/people_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ssbc/go-ssb"
 	refs "github.com/ssbc/go-ssb-refs"
 	"github.com/ssbc/go-ssb/internal/storedrefs"
-	"github.com/ssbc/go-ssb/internal/testutils"
 	"github.com/ssbc/go-ssb/multilogs"
 )
 
@@ -243,11 +242,6 @@ type PeopleTestCase struct {
 
 func (tc PeopleTestCase) run(mk func(t *testing.T) testStore) func(t *testing.T) {
 	return func(t *testing.T) {
-		if testutils.SkipOnCI(t) {
-			// https://github.com/ssbc/go-ssb/issues/163
-			return
-		}
-
 		r := require.New(t)
 		a := assert.New(t)
 

--- a/sbot/new.go
+++ b/sbot/new.go
@@ -155,7 +155,7 @@ type Sbot struct {
 
 	verifyRouter *message.VerificationRouter
 
-	GraphBuilder graph.Builder
+	GraphBuilder *graph.BadgerBuilder
 
 	BlobStore   ssb.BlobStore
 	WantManager ssb.WantManager
@@ -857,7 +857,7 @@ func New(fopts ...Option) (*Sbot, error) {
 		}
 
 		if strings.HasPrefix(req.URL.Path, graphDumpPathPrefix) {
-			s.GraphBuilder.(*graph.BadgerBuilder).DumpXMLOverHTTP(s.KeyPair.ID(), w, req)
+			s.GraphBuilder.DumpXMLOverHTTP(s.KeyPair.ID(), w, req)
 			return
 		}
 


### PR DESCRIPTION
Based on #322 

Adds more synchronization to sbot's `WaitUntilIndexesAreSynced()`, which should in general fix a bunch of potential race conditions before they pop up and just generally make indexing more reliable.