### PR TITLE
chore: bump tags for millisecs fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,9 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rs/cors v1.8.3
 	github.com/shurcooL/go-goon v1.0.0
-	github.com/ssbc/go-gabbygrove v0.0.0-20221025092911-c274a44c3523
+	github.com/ssbc/go-gabbygrove v0.2.2
 	github.com/ssbc/go-luigi v0.3.7-0.20230119190114-bd28e676fa99
-	github.com/ssbc/go-metafeed v1.1.3-0.20221019090205-458925e39156
+	github.com/ssbc/go-metafeed v1.1.3
 	github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221111190521-10382533750c
 	github.com/ssbc/go-netwrap v0.1.5-0.20221019160355-cd323bb2e29d
 	github.com/ssbc/go-secretstream v1.2.11-0.20221019175226-fa042d4912fe

--- a/go.sum
+++ b/go.sum
@@ -518,13 +518,13 @@ github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tL
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/ssbc/go-gabbygrove v0.0.0-20221025092911-c274a44c3523 h1:veYe4pNgQ5nKHruw2pdllHIJH7Oqg7Onk9F1DKbVTqk=
-github.com/ssbc/go-gabbygrove v0.0.0-20221025092911-c274a44c3523/go.mod h1:CKx4WZRQFAjhnFniMtqdPy8T1oRR0O6yZ1nP7cVKgZM=
+github.com/ssbc/go-gabbygrove v0.2.2 h1:NI53NZDqVZGCafhX6MxvQAdVqrEXdUPQoH1rXuatQdM=
+github.com/ssbc/go-gabbygrove v0.2.2/go.mod h1:0+ELheqecHxJMLHhKuq8bmcE9gCOzKZKHQdtlqlNDKQ=
 github.com/ssbc/go-luigi v0.3.7-0.20221019204020-324065b9a7c6/go.mod h1:tBPMBysJeh1u3vStvrWe5w3YBC4fnbnGsLk5ML4D6do=
 github.com/ssbc/go-luigi v0.3.7-0.20230119190114-bd28e676fa99 h1:qy9SdIIFwM+4SuKtBZyJVoIL02/V0YvqDBi8qIRQlls=
 github.com/ssbc/go-luigi v0.3.7-0.20230119190114-bd28e676fa99/go.mod h1:tBPMBysJeh1u3vStvrWe5w3YBC4fnbnGsLk5ML4D6do=
-github.com/ssbc/go-metafeed v1.1.3-0.20221019090205-458925e39156 h1:9fMiwqFKVsvTgDWbfhtMSmKCU8xfUIK2q2oNANmLO2E=
-github.com/ssbc/go-metafeed v1.1.3-0.20221019090205-458925e39156/go.mod h1:+Pm/jgfvaDY1aHsu24fPlTLMlM20F3MCTLUVFJ7nBgo=
+github.com/ssbc/go-metafeed v1.1.3 h1:RNPc0nb5hGdPAPXMyV37MqvmS6XWcjW2KGpd1ecViks=
+github.com/ssbc/go-metafeed v1.1.3/go.mod h1:oaLOCbKYhQ0gskmRs3IMa3SnNTs7wPIzoa6puEJoFDI=
 github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221111190521-10382533750c h1:xqjaqcG0diMshLo0OaujvHE96OFrd/GiCTJYCTrPVhE=
 github.com/ssbc/go-muxrpc/v2 v2.0.14-0.20221111190521-10382533750c/go.mod h1:CFvV9kCI3SmJM38pf1NCXWrS7UVgTYXJdKs+Q9hkJIw=
 github.com/ssbc/go-netwrap v0.1.5-0.20221019160355-cd323bb2e29d h1:UnYPPekKU0mHzMMOSuI6117Djq9xni60c/IzzUYxgCI=
@@ -534,8 +534,6 @@ github.com/ssbc/go-secretstream v1.2.11-0.20221019175226-fa042d4912fe/go.mod h1:
 github.com/ssbc/go-ssb-multiserver v0.1.5-0.20221019203850-917ae0e23d57 h1:wfIu3HcI8HGLSbJFo35eKMjFBMhHhXJsYGTAOVhpNkQ=
 github.com/ssbc/go-ssb-multiserver v0.1.5-0.20221019203850-917ae0e23d57/go.mod h1:LMJaMYVJxtYKTj8A0t8+iM+K2/SuYSvp14urj9sHLa8=
 github.com/ssbc/go-ssb-refs v0.5.2-0.20221017100922-8e95413c6580/go.mod h1:rUj40X7iiUWFt62aF4NVm3uNnKiPZ9Uo/ds4D4ZE980=
-github.com/ssbc/go-ssb-refs v0.5.2-0.20221019090322-8b558c2f31de h1:av0v73MeB+HASXfbtr3+r1dWD1DrYlGEIMCdVKV09Ag=
-github.com/ssbc/go-ssb-refs v0.5.2-0.20221019090322-8b558c2f31de/go.mod h1:TRIqkOhZERfVzB+NoO3eUoru0ceQAsDnfZricPd1sUM=
 github.com/ssbc/go-ssb-refs v0.5.2 h1:PDjtfRMywwsP69pNdiCh/P9gj95W4iJsrQo5uDus0EY=
 github.com/ssbc/go-ssb-refs v0.5.2/go.mod h1:HlojPQQVXjZv+rqOnDVaZo5c8kwJQC7kpejcRqOJ54o=
 github.com/ssbc/margaret v0.4.4-0.20221101112304-4f5815095ef3 h1:oA9tmdVzuTKZUF7cipd61SCKz69ceOZhrvgWC9rcUWU=


### PR DESCRIPTION
Following up on https://github.com/ssbc/go-ssb/pull/325.