### PR TITLE
Optimize VerifyWithBuffer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-kit/kit v0.12.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/json-iterator/go v1.1.12
 	github.com/keks/persist v0.0.0-20210520094901-9bdd97c1fad2
 	github.com/keks/testops v0.1.0
 	github.com/komkom/toml v0.1.2
@@ -72,6 +73,8 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/matryer/is v1.3.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -390,9 +391,11 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=

--- a/message/legacy/encode.go
+++ b/message/legacy/encode.go
@@ -98,13 +98,15 @@ func (pp *prettyPrinter) formatArray(depth int) error {
 	}
 
 	pp.buffer.WriteString("[")
-	pp.buffer.WriteString("\n")
-
 	i := 0
 	for {
 		ok := pp.iter.ReadArray()
 		if !ok {
 			break
+		}
+
+		if i == 0 {
+			pp.buffer.WriteString("\n")
 		}
 
 		if i > 0 {
@@ -140,7 +142,7 @@ func (pp *prettyPrinter) formatArray(depth int) error {
 			}
 
 		case jsoniter.ArrayValue:
-			if err := pp.formatArray(depth); err != nil {
+			if err := pp.formatArray(depth + 1); err != nil {
 				return err
 			}
 
@@ -151,8 +153,10 @@ func (pp *prettyPrinter) formatArray(depth int) error {
 		i++
 	}
 
-	pp.buffer.WriteString("\n")
-	pp.buffer.WriteString(strings.Repeat("  ", depth-1))
+	if i > 0 {
+		pp.buffer.WriteString("\n")
+		pp.buffer.WriteString(strings.Repeat("  ", depth-1))
+	}
 	pp.buffer.WriteString("]")
 
 	return nil

--- a/message/legacy/encode.go
+++ b/message/legacy/encode.go
@@ -212,7 +212,7 @@ func (pp *prettyPrinter) formatBool() error {
 
 func (pp *prettyPrinter) writeString(v string) {
 	pp.buffer.WriteByte('"')
-	pp.buffer.WriteString(unicodeEscapeSome(replacer.Replace(v)))
+	unicodeEscapeSome(pp.buffer, replacer.Replace(v))
 	pp.buffer.WriteByte('"')
 }
 

--- a/message/legacy/encode.go
+++ b/message/legacy/encode.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 )
 
-var replacer = strings.NewReplacer("\\", `\\`, "\t", `\t`, "\n", `\n`, "\r", `\r`, `"`, `\"`)
-
 var iteratorConfig = jsoniter.Config{
 	// re float encoding: https://spec.scuttlebutt.nz/datamodel.html#signing-encoding-floats
 	// not particular excited to implement all of the above
@@ -212,7 +210,7 @@ func (pp *prettyPrinter) formatBool() error {
 
 func (pp *prettyPrinter) writeString(v string) {
 	pp.buffer.WriteByte('"')
-	unicodeEscapeSome(pp.buffer, replacer.Replace(v))
+	unicodeEscapeSome(pp.buffer, v)
 	pp.buffer.WriteByte('"')
 }
 

--- a/message/legacy/replace.go
+++ b/message/legacy/replace.go
@@ -16,9 +16,7 @@ import (
 
 var hex = "0123456789abcdef"
 
-func unicodeEscapeSome(s string) string {
-	buf := bytes.NewBuffer(make([]byte, 0, len(s)))
-
+func unicodeEscapeSome(buf *bytes.Buffer, s string) {
 	start := 0
 	for i := 0; i < len(s); {
 		if b := s[i]; b < utf8.RuneSelf {
@@ -65,9 +63,6 @@ func unicodeEscapeSome(s string) string {
 	if start < len(s) {
 		buf.WriteString(s[start:])
 	}
-
-	return buf.String()
-
 }
 
 // InternalV8Binary does some funky v8 magic

--- a/message/legacy/replace.go
+++ b/message/legacy/replace.go
@@ -32,6 +32,14 @@ func unicodeEscapeSome(buf *bytes.Buffer, s string) {
 			buf.WriteByte('\\')
 
 			switch b {
+			case '\\', '"':
+				buf.WriteByte(b)
+			case '\n':
+				buf.WriteByte('n')
+			case '\r':
+				buf.WriteByte('r')
+			case '\t':
+				buf.WriteByte('t')
 			case '\b':
 				buf.WriteByte('b')
 			case '\f':
@@ -91,7 +99,7 @@ func InternalV8Binary(in []byte) ([]byte, error) {
 var safeSet = [utf8.RuneSelf]bool{
 	' ':      true,
 	'!':      true,
-	'"':      true,
+	'"':      false,
 	'#':      true,
 	'$':      true,
 	'%':      true,
@@ -149,7 +157,7 @@ var safeSet = [utf8.RuneSelf]bool{
 	'Y':      true,
 	'Z':      true,
 	'[':      true,
-	'\\':     true,
+	'\\':     false,
 	']':      true,
 	'^':      true,
 	'_':      true,

--- a/message/legacy/replace.go
+++ b/message/legacy/replace.go
@@ -14,26 +14,60 @@ import (
 	"golang.org/x/text/transform"
 )
 
+var hex = "0123456789abcdef"
+
 func unicodeEscapeSome(s string) string {
-	var b bytes.Buffer
-	for i, r := range s {
-		// https://spec.scuttlebutt.nz/feed/datamodel.html#signing-encoding-strings
-		// the rest is already handled by %q in encode.go
-		if r == 0x000008 {
-			// (backspace) \b
-			b.Write([]byte{0x5C, 0x62})
-		} else if r == 0x00000C {
-			// (form feed) \f
-			b.Write([]byte{0x5C, 0x66})
-		} else if r < 0x20 {
-			// TODO: width for multibyte chars
-			runeValue, _ := utf8.DecodeRuneInString(s[i:])
-			fmt.Fprintf(&b, "\\u%04x", runeValue)
-		} else {
-			fmt.Fprintf(&b, "%c", r)
+	buf := bytes.NewBuffer(make([]byte, 0, len(s)))
+
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if safeSet[b] {
+				i++
+				continue
+			}
+
+			if start < i {
+				buf.WriteString(s[start:i])
+			}
+
+			buf.WriteByte('\\')
+
+			switch b {
+			case '\b':
+				buf.WriteByte('b')
+			case '\f':
+				buf.WriteByte('f')
+			default:
+				buf.WriteString(`u00`)
+				buf.WriteByte(hex[b>>4])
+				buf.WriteByte(hex[b&0xF])
+			}
+
+			i++
+			start = i
+			continue
 		}
+
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				buf.WriteString(s[start:i])
+			}
+			buf.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+
+		i += size
 	}
-	return b.String()
+	if start < len(s) {
+		buf.WriteString(s[start:])
+	}
+
+	return buf.String()
+
 }
 
 // InternalV8Binary does some funky v8 magic
@@ -57,4 +91,103 @@ func InternalV8Binary(in []byte) ([]byte, error) {
 		j++
 	}
 	return z, nil
+}
+
+var safeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      true,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     true,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
 }

--- a/message/legacy/replace.go
+++ b/message/legacy/replace.go
@@ -16,7 +16,8 @@ import (
 
 var hex = "0123456789abcdef"
 
-func unicodeEscapeSome(buf *bytes.Buffer, s string) {
+// https://262.ecma-international.org/6.0/#sec-quotejsonstring
+func quoteString(buf *bytes.Buffer, s string) {
 	start := 0
 	for i := 0; i < len(s); {
 		if b := s[i]; b < utf8.RuneSelf {

--- a/message/legacy/replace_test.go
+++ b/message/legacy/replace_test.go
@@ -31,24 +31,21 @@ func TestStripSignature(t *testing.T) {
 	var (
 		input = []byte(`{
   "foo": "hello",
-  "signature": "aBISzGroszUndKlein01234567890/+="
+  "signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==.sig.ed25519"
 }`)
 		want = []byte(`{
   "foo": "hello"
 }`)
-		wantSig = []byte("aBISzGroszUndKlein01234567890/+=")
 	)
-	matches := signatureRegexp.FindSubmatch(input)
-	if n := len(matches); n != 2 {
-		t.Fatalf("expected 2 results, got %d", n)
-	}
-	if s := matches[1]; bytes.Compare(s, wantSig) != 0 {
-		t.Errorf("unexpected submatch: %s", s)
-	}
-	out := signatureRegexp.ReplaceAll(input, []byte{})
-	if bytes.Compare(out, want) != 0 {
-		t.Errorf("got unexpected replace:\n%s", out)
-	}
+
+	wantSig, err := NewSignatureFromBase64([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==.sig.ed25519"))
+	require.NoError(t, err)
+
+	msg, sig, err := ExtractSignature(input)
+	require.NoError(t, err)
+
+	require.Equal(t, want, msg)
+	require.Equal(t, wantSig, sig)
 }
 
 func TestUnicodeFind(t *testing.T) {

--- a/message/legacy/replace_test.go
+++ b/message/legacy/replace_test.go
@@ -51,8 +51,9 @@ func TestStripSignature(t *testing.T) {
 func TestUnicodeFind(t *testing.T) {
 	in := "Hello\x01World"
 	want := `Hello\u0001World`
-	out := unicodeEscapeSome(in)
-	assert.Equal(t, want, out)
+	buf := &bytes.Buffer{}
+	unicodeEscapeSome(buf, in)
+	assert.Equal(t, want, buf.String())
 }
 
 func getHexBytesFromNode(t *testing.T, input, encoding string) []byte {

--- a/message/legacy/signature.go
+++ b/message/legacy/signature.go
@@ -31,7 +31,7 @@ func ExtractSignature(b []byte) ([]byte, Signature, error) {
 	// NOTE(boreq): this seems like expected behaviour to me.
 
 	lines := bytes.Split(b, jsonLineSeparator)
-	for i := range lines {
+	for i := len(lines) - 1; i >= 0; i-- {
 		if bytes.HasSuffix(lines[i], jsonSignatureSuffix) {
 			signature, err := extractSignature(lines[i])
 			if err != nil {

--- a/message/legacy/signature.go
+++ b/message/legacy/signature.go
@@ -13,29 +13,69 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
 
 	refs "github.com/ssbc/go-ssb-refs"
 )
 
-var signatureRegexp = regexp.MustCompile(",\n  \"signature\": \"([A-Za-z0-9/+=.]+)\"")
+var (
+	jsonLineSeparator   = []byte("\n")
+	jsonSignatureSuffix = []byte(`.sig.ed25519"`)
+	jsonQuote           = []byte(`"`)
+	jsonComma           = []byte(`,`)
+)
 
 // ExtractSignature expects a pretty printed message and uses a regexp to strip it from the msg for signature verification
 func ExtractSignature(b []byte) ([]byte, Signature, error) {
 	// BUG(cryptix): this expects signature on the root of the object.
 	// some functions (like createHistoryStream with keys:true) nest the message on level deeper and this fails
-	matches := signatureRegexp.FindSubmatch(b)
-	if n := len(matches); n != 2 {
-		return nil, nil, fmt.Errorf("ssb/ExtractSignature: expected signature in formatted bytes. Only %d matches", n)
-	}
-	msg := signatureRegexp.ReplaceAll(b, []byte{})
+	// NOTE(boreq): this seems like expected behaviour to me.
 
-	sig, err := NewSignatureFromBase64(matches[1])
-	if err != nil {
-		fmt.Printf("\t\tbase64? %s\n", matches[1])
-		return nil, nil, fmt.Errorf("ssb/ExtractSignature: invalid base64 data: %w", err)
+	lines := bytes.Split(b, jsonLineSeparator)
+	for i := range lines {
+		if bytes.HasSuffix(lines[i], jsonSignatureSuffix) {
+			signature, err := extractSignature(lines[i])
+			if err != nil {
+				return nil, nil, fmt.Errorf("error extracting signature: %w", err)
+			}
+
+			lines = append(lines[:i], lines[i+1:]...)
+			if i == 0 {
+				return nil, nil, errors.New("this message seems malformed, signature should be at the end of it")
+			}
+
+			if !bytes.HasSuffix(lines[i-1], jsonComma) {
+				return nil, nil, errors.New("this message seems malformed, previous line should have a comma at the end")
+			}
+
+			lines[i-1] = bytes.TrimSuffix(lines[i-1], jsonComma)
+			msg := bytes.Join(lines, []byte("\n"))
+			return msg, signature, nil
+		}
 	}
-	return msg, sig, nil
+
+	return nil, nil, errors.New("signature not found")
+}
+
+func extractSignature(line []byte) (Signature, error) {
+	closingQuoteIndex := bytes.LastIndex(line, jsonQuote)
+	if closingQuoteIndex < 0 {
+		return nil, errors.New("closing quote not found")
+	}
+	line = line[:closingQuoteIndex]
+
+	openingQuoteIndex := bytes.LastIndex(line, jsonQuote)
+	if openingQuoteIndex < 0 {
+		return nil, errors.New("opening quote not found")
+	}
+
+	line = line[openingQuoteIndex+1:]
+
+	sig, err := NewSignatureFromBase64(line)
+	if err != nil {
+		return nil, fmt.Errorf("error creating signature from base64 data: %w", err)
+	}
+
+	return sig, nil
 }
 
 type Signature []byte
@@ -58,16 +98,19 @@ func NewSignatureFromBase64(input []byte) (Signature, error) {
 	}
 
 	// decode and check lengths
-	decoded, err := base64.StdEncoding.DecodeString(string(b64))
+	decoded := make([]byte, gotLen)
+	n, err := base64.StdEncoding.Decode(decoded, b64)
 	if err != nil {
 		return nil, fmt.Errorf("ssb/signature: invalid base64 data: %w", err)
 	}
+	decoded = decoded[:n]
+
 	decodedLen := len(decoded)
 	if decodedLen != ed25519.SignatureSize {
 		return nil, fmt.Errorf("ssb/signature: decoded data is %d bytes long and should be %d", decodedLen, ed25519.SignatureSize)
 	}
 
-	return Signature(decoded), err
+	return decoded, err
 }
 
 var signatureSuffix = []byte(".sig.ed25519")

--- a/message/legacy/signature.go
+++ b/message/legacy/signature.go
@@ -48,7 +48,7 @@ func ExtractSignature(b []byte) ([]byte, Signature, error) {
 			}
 
 			lines[i-1] = bytes.TrimSuffix(lines[i-1], jsonComma)
-			msg := bytes.Join(lines, []byte("\n"))
+			msg := bytes.Join(lines, jsonLineSeparator)
 			return msg, signature, nil
 		}
 	}

--- a/message/legacy/verify.go
+++ b/message/legacy/verify.go
@@ -13,11 +13,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io"
-	"strings"
-
+	jsoniter "github.com/json-iterator/go"
 	refs "github.com/ssbc/go-ssb-refs"
 	"golang.org/x/crypto/nacl/auth"
+	"io"
 )
 
 var (
@@ -49,6 +48,11 @@ func runeLength(s string) int {
 	return len(runes)
 }
 
+var (
+	boxSuffix  = []byte(`.box"`)
+	box2Suffix = []byte(`.box2""`)
+)
+
 func VerifyWithBuffer(raw []byte, hmacSecret *[32]byte, buf *bytes.Buffer) (refs.MessageRef, DeserializedMessage, error) {
 	enc, err := PrettyPrint(raw, WithBuffer(buf), WithStrictOrderChecking(true))
 	if err != nil {
@@ -60,7 +64,7 @@ func VerifyWithBuffer(raw []byte, hmacSecret *[32]byte, buf *bytes.Buffer) (refs
 
 	// this unmarshal destroys it for the network layer but makes it easier to access its values
 	var dmsg DeserializedMessage
-	if err := json.Unmarshal(raw, &dmsg); err != nil {
+	if err := jsoniter.Unmarshal(raw, &dmsg); err != nil {
 		if len(raw) > 32 {
 			raw = append(raw[:32], '.', '.', '.')
 		}
@@ -85,7 +89,7 @@ func VerifyWithBuffer(raw []byte, hmacSecret *[32]byte, buf *bytes.Buffer) (refs
 		var typedContent struct {
 			Type string
 		}
-		err = json.Unmarshal(dmsg.Content, &typedContent)
+		err = jsoniter.Unmarshal(dmsg.Content, &typedContent)
 		if err != nil {
 			return emptyMsgRef, emptyDMsg, err
 		}
@@ -96,14 +100,8 @@ func VerifyWithBuffer(raw []byte, hmacSecret *[32]byte, buf *bytes.Buffer) (refs
 		}
 
 	case '"': // if it's a JSON string
-		var justString string
-		err = json.Unmarshal(dmsg.Content, &justString)
-		if err != nil {
-			return emptyMsgRef, emptyDMsg, err
-		}
-
 		// only allow known suffixes
-		if !strings.HasSuffix(justString, ".box") && !strings.HasSuffix(justString, ".box2") {
+		if !bytes.HasSuffix(dmsg.Content, boxSuffix) && !bytes.HasSuffix(dmsg.Content, box2Suffix) {
 			return emptyMsgRef, emptyDMsg, fmt.Errorf("ssb Verify: scuttlebutt v1 private messages need to have the right suffix")
 		}
 

--- a/message/legacy/verify.go
+++ b/message/legacy/verify.go
@@ -50,7 +50,7 @@ func runeLength(s string) int {
 
 var (
 	boxSuffix  = []byte(`.box"`)
-	box2Suffix = []byte(`.box2""`)
+	box2Suffix = []byte(`.box2"`)
 )
 
 func VerifyWithBuffer(raw []byte, hmacSecret *[32]byte, buf *bytes.Buffer) (refs.MessageRef, DeserializedMessage, error) {

--- a/message/legacy/verify_test.go
+++ b/message/legacy/verify_test.go
@@ -50,3 +50,16 @@ func TestVerifyBugs(t *testing.T) {
 		a.Equal(tc.seq, dmsg.Sequence)
 	}
 }
+
+func BenchmarkVerify(b *testing.B) {
+	msg := []byte(`{"previous":"%Ou364gh9oMmjRDUaUKeXlVZzYiEdjEz00NEGXaRtnrQ=.sha256","author":"@NaDXehMSIgk08W5RXZJ0p+7m+19iIWEuAtD7FRESJX8=.ed25519","sequence":1134,"timestamp":1515151248938,"hash":"sha256","content":{"type":"post","channel":"alienintelligence","text":"### [THE FIRST POST-KEPLER BRIGHTNESS DIPS OF KIC 8462852](https://arxiv.org/pdf/1801.00732.pdf) \n#### aka alien megastructure (Dyson Swarm/Ring)\n\n> In the case of Tabby's star, the new observations show that it dims more at blue wavelengths than red. Thus, its light is passing through a dust cloud, not being blocked by an alien megastructure in orbit around the star. The new analysis of KIC 8462852 showing these results is to be published in The Astrophysical Journal Letters. It reinforces the conclusions reached by Huan Meng, University of Arizona, Tucson, and collaborators in October 2017. They monitored the star at multiple wavelengths using Nasa's Spitzer and Swift missions, and the Belgian AstroLAB IRIS observatory. These results were published in The Astrophysical Journal.\n\n> The photometric monitoring of KIC 8462852 is the first successful effort via crowd-funding to study an astronomical object.\n\n> Multiband photometry taken during Elsie show its amplitude is chromatic, with depth ratios that are consistent with occultation by optically thin dust with size scales \u001c 1µm, and perhaps with variations ntrinsic to the star.\n\n> KIC 8462852 has captured the imagination of both scientists and the public. To that end, our team strives to make the steps taken to learn more about the star as transparent as possible. Additional constraints on the system will come from the triggered observations taken during the Elsie family of dips and beyond, which will in turn allow for more detailed modeling. Opportunities include observational projects from numerous facilities, impressively demonstrating the multidimensional approach of the community to study KIC 8462852, as mentioned within the above sections. The observed “colors” of the dips (i.e. the ratios of\nthe dip depths in different bands) appear inconsistent with occultation by primarily optically thick material (which would be expected to produce nearly achromatic dips) and appear to be in some tension with intrinsic cooling of the star at constant radius.\n\nOk, so we found out it's uneven ring of dust?\n\n[source](https://science.slashdot.org/story/18/01/04/2352244/the-alien-megastructure-around-mysterious-tabbys-star-is-probably-just-dust-analysis-shows)\n[2](https://en.wikipedia.org/wiki/KIC_8462852)","mentions":[]},"signature":"P9Di8JWeVo9fAIKVkPZiCaib1CjuKYX5EzSqu7lGhpjTeTR/5+Gprsz69fBJGSYWnJdozwfqYh/cRWsfhT55CA==.sig.ed25519"}`)
+
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := Verify(msg, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/message/legacy/verify_test.go
+++ b/message/legacy/verify_test.go
@@ -52,14 +52,14 @@ func TestVerifyBugs(t *testing.T) {
 }
 
 func BenchmarkVerify(b *testing.B) {
-	msg := []byte(`{"previous":"%Ou364gh9oMmjRDUaUKeXlVZzYiEdjEz00NEGXaRtnrQ=.sha256","author":"@NaDXehMSIgk08W5RXZJ0p+7m+19iIWEuAtD7FRESJX8=.ed25519","sequence":1134,"timestamp":1515151248938,"hash":"sha256","content":{"type":"post","channel":"alienintelligence","text":"### [THE FIRST POST-KEPLER BRIGHTNESS DIPS OF KIC 8462852](https://arxiv.org/pdf/1801.00732.pdf) \n#### aka alien megastructure (Dyson Swarm/Ring)\n\n> In the case of Tabby's star, the new observations show that it dims more at blue wavelengths than red. Thus, its light is passing through a dust cloud, not being blocked by an alien megastructure in orbit around the star. The new analysis of KIC 8462852 showing these results is to be published in The Astrophysical Journal Letters. It reinforces the conclusions reached by Huan Meng, University of Arizona, Tucson, and collaborators in October 2017. They monitored the star at multiple wavelengths using Nasa's Spitzer and Swift missions, and the Belgian AstroLAB IRIS observatory. These results were published in The Astrophysical Journal.\n\n> The photometric monitoring of KIC 8462852 is the first successful effort via crowd-funding to study an astronomical object.\n\n> Multiband photometry taken during Elsie show its amplitude is chromatic, with depth ratios that are consistent with occultation by optically thin dust with size scales \u001c 1µm, and perhaps with variations ntrinsic to the star.\n\n> KIC 8462852 has captured the imagination of both scientists and the public. To that end, our team strives to make the steps taken to learn more about the star as transparent as possible. Additional constraints on the system will come from the triggered observations taken during the Elsie family of dips and beyond, which will in turn allow for more detailed modeling. Opportunities include observational projects from numerous facilities, impressively demonstrating the multidimensional approach of the community to study KIC 8462852, as mentioned within the above sections. The observed “colors” of the dips (i.e. the ratios of\nthe dip depths in different bands) appear inconsistent with occultation by primarily optically thick material (which would be expected to produce nearly achromatic dips) and appear to be in some tension with intrinsic cooling of the star at constant radius.\n\nOk, so we found out it's uneven ring of dust?\n\n[source](https://science.slashdot.org/story/18/01/04/2352244/the-alien-megastructure-around-mysterious-tabbys-star-is-probably-just-dust-analysis-shows)\n[2](https://en.wikipedia.org/wiki/KIC_8462852)","mentions":[]},"signature":"P9Di8JWeVo9fAIKVkPZiCaib1CjuKYX5EzSqu7lGhpjTeTR/5+Gprsz69fBJGSYWnJdozwfqYh/cRWsfhT55CA==.sig.ed25519"}`)
-
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, _, err := Verify(msg, nil)
-		if err != nil {
-			b.Fatal(err)
+		for j := 1; j < len(testMessages); j++ {
+			_, _, err := Verify(testMessages[j].Input, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request aims to optimize message verification. This is likely to be a hot path in any SSB app and is especially important during initial replication. The speedup visible here won't be directly reflected in the initial replication being proportionally faster in the clients using go-ssb as they will have other overhead as well e.g. the database layer but it should still significantly speed it up. 

Ok this is quite large now but focused on optimizing various functions called from `Verify`. I changed `ExtractSignature` to avoid costly regexp usage and avoid converting bytes to string in `NewSignatureFromBase64`. I replaced `unicodeEscapeSome` function with a faster alternative which attempts to optimize for the common scenario of most characters not
needing escaping and was partially taken from `encoding/json`. Initially I tried to simply optimize `PrettyPrint` as it contained a lot of inefficient code but  In the end I was forced to completely rewrite `PrettyPrint` as `encoding/json` is just too slow. Instead I used `https://github.com/json-iterator/go`.

Before this pull request:
```
BenchmarkVerify-16    	     274	  43425441 ns/op	19687724 B/op	   90084 allocs/op
```

After this pull request:
```
BenchmarkVerify-16    	     613	  19428600 ns/op	 5285056 B/op	   23057 allocs/op
```

That is 45% of original execution time and 26% of original number of allocs.