### PR TITLE
Further optimizations to VerifyWithBuffer

### DIFF
--- a/message/legacy/encode.go
+++ b/message/legacy/encode.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	jsoniter "github.com/json-iterator/go"
-	"strings"
 )
 
 var iteratorConfig = jsoniter.Config{
@@ -36,7 +35,7 @@ func (pp *prettyPrinter) formatObject(depth int) error {
 			pp.buffer.WriteString(",\n")
 		}
 
-		pp.buffer.WriteString(strings.Repeat("  ", depth))
+		pp.writeIndent(depth)
 		pp.writeString(s)
 		pp.buffer.WriteString(": ")
 
@@ -89,7 +88,7 @@ func (pp *prettyPrinter) formatObject(depth int) error {
 	}
 
 	pp.buffer.WriteString("\n")
-	pp.buffer.WriteString(strings.Repeat("  ", depth-1))
+	pp.writeIndent(depth - 1)
 	pp.buffer.WriteString("}")
 
 	return nil
@@ -116,7 +115,7 @@ func (pp *prettyPrinter) formatArray(depth int) error {
 			pp.buffer.WriteString(",\n")
 		}
 
-		pp.buffer.WriteString(strings.Repeat("  ", depth))
+		pp.writeIndent(depth)
 
 		switch whatIsNext := pp.iter.WhatIsNext(); whatIsNext {
 		case jsoniter.ObjectValue:
@@ -158,7 +157,7 @@ func (pp *prettyPrinter) formatArray(depth int) error {
 
 	if i > 0 {
 		pp.buffer.WriteString("\n")
-		pp.buffer.WriteString(strings.Repeat("  ", depth-1))
+		pp.writeIndent(depth - 1)
 	}
 	pp.buffer.WriteString("]")
 
@@ -217,6 +216,36 @@ func (pp *prettyPrinter) writeString(v string) {
 	pp.buffer.WriteByte('"')
 	quoteString(pp.buffer, v)
 	pp.buffer.WriteByte('"')
+}
+
+var (
+	indentBytes      = []byte("  ")
+	indentBytesOne   = bytes.Repeat(indentBytes, 1)
+	indentBytesTwo   = bytes.Repeat(indentBytes, 2)
+	indentBytesThree = bytes.Repeat(indentBytes, 3)
+	indentBytesFour  = bytes.Repeat(indentBytes, 4)
+	indentBytesFive  = bytes.Repeat(indentBytes, 5)
+)
+
+func (pp *prettyPrinter) writeIndent(depth int) {
+	if depth == 0 {
+		return
+	}
+
+	switch depth {
+	case 1:
+		pp.buffer.Write(indentBytesOne)
+	case 2:
+		pp.buffer.Write(indentBytesTwo)
+	case 3:
+		pp.buffer.Write(indentBytesThree)
+	case 4:
+		pp.buffer.Write(indentBytesFour)
+	case 5:
+		pp.buffer.Write(indentBytesFive)
+	default:
+		pp.buffer.Write(bytes.Repeat(indentBytes, depth))
+	}
 }
 
 type PrettyPrinterOption func(pp *prettyPrinter)

--- a/message/legacy/encode.go
+++ b/message/legacy/encode.go
@@ -308,7 +308,8 @@ func PrettyPrint(input []byte, opts ...PrettyPrinterOption) ([]byte, error) {
 	}
 
 	if pp.buffer == nil {
-		pp.buffer = new(bytes.Buffer)
+		guessedSize := len(input)
+		pp.buffer = bytes.NewBuffer(make([]byte, 0, guessedSize))
 	}
 
 	if err := pp.formatObject(1); err != nil {

--- a/message/legacy/encode.go
+++ b/message/legacy/encode.go
@@ -234,19 +234,11 @@ func WithStrictOrderChecking(yes bool) PrettyPrinterOption {
 	}
 }
 
-// some constants for field order checking
-const acceptedFieldOrderDelimiter = ":"
-
-// (slices can't be const, though)
 var (
 	acceptedFieldOrderList = [][]string{
 		{"previous", "author", "sequence", "timestamp", "hash", "content", "signature"},
 		{"previous", "sequence", "author", "timestamp", "hash", "content", "signature"},
 	}
-
-	acceptedFieldOrderLength int
-
-	acceptedFieldOrders = make([]string, len(acceptedFieldOrderList))
 )
 
 // init the strings.Joined version of acceptedFieldOrderList for checkFieldOrder()
@@ -254,34 +246,31 @@ var (
 func init() {
 	fieldListLen := -1
 	for i, order := range acceptedFieldOrderList {
-
 		// length assertion
 		sliceLen := len(order)
 		if i == 0 {
 			fieldListLen = sliceLen
-			acceptedFieldOrderLength = sliceLen
 		} else {
 			if fieldListLen != sliceLen {
 				panic("inconsistent length of acceptedFieldOrderList")
-				// TODO: change checkFieldOrder length check
 			}
 		}
-
-		acceptedFieldOrders[i] = strings.Join(order, acceptedFieldOrderDelimiter)
 	}
 }
 
 func checkFieldOrder(fields []string) error {
-	if n := len(fields); n != acceptedFieldOrderLength {
-		return fmt.Errorf("ssb/verify: invalid field order length (%d)", n)
-	}
-
-	gotFields := strings.Join(fields, acceptedFieldOrderDelimiter)
-
-	for _, accepted := range acceptedFieldOrders {
-		if accepted == gotFields {
-			return nil
+	for _, acceptedFieldOrder := range acceptedFieldOrderList {
+		if len(fields) != len(acceptedFieldOrder) {
+			continue
 		}
+
+		for i := range acceptedFieldOrder {
+			if acceptedFieldOrder[i] != fields[i] {
+				continue
+			}
+		}
+
+		return nil
 	}
 
 	return fmt.Errorf("ssb/verify: invalid field order: %v", fields)

--- a/message/legacy/encode.go
+++ b/message/legacy/encode.go
@@ -289,20 +289,25 @@ func init() {
 
 func checkFieldOrder(fields []string) error {
 	for _, acceptedFieldOrder := range acceptedFieldOrderList {
-		if len(fields) != len(acceptedFieldOrder) {
-			continue
+		if err := fieldOrderIsValid(fields, acceptedFieldOrder); err == nil {
+			return nil
 		}
+	}
+	return fmt.Errorf("ssb/verify: invalid field order: %v", fields)
+}
 
-		for i := range acceptedFieldOrder {
-			if acceptedFieldOrder[i] != fields[i] {
-				continue
-			}
-		}
-
-		return nil
+func fieldOrderIsValid(fields []string, acceptedFieldOrder []string) error {
+	if len(fields) != len(acceptedFieldOrder) {
+		return errors.New("invalid length")
 	}
 
-	return fmt.Errorf("ssb/verify: invalid field order: %v", fields)
+	for i := range acceptedFieldOrder {
+		if acceptedFieldOrder[i] != fields[i] {
+			return errors.New("different fields")
+		}
+	}
+
+	return nil
 }
 
 type prettyPrinter struct {

--- a/message/legacy/verify.go
+++ b/message/legacy/verify.go
@@ -17,6 +17,7 @@ import (
 	refs "github.com/ssbc/go-ssb-refs"
 	"golang.org/x/crypto/nacl/auth"
 	"io"
+	"unicode/utf8"
 )
 
 var (
@@ -41,11 +42,6 @@ type DeserializedMessage struct {
 func Verify(raw []byte, hmacSecret *[32]byte) (refs.MessageRef, DeserializedMessage, error) {
 	var buf bytes.Buffer
 	return VerifyWithBuffer(raw, hmacSecret, &buf)
-}
-
-func runeLength(s string) int {
-	runes := []rune(s)
-	return len(runes)
 }
 
 var (
@@ -77,10 +73,14 @@ func VerifyWithBuffer(raw []byte, hmacSecret *[32]byte, buf *bytes.Buffer) (refs
 	}
 
 	// check length
-	if n := len(dmsg.Content); n < 1 {
-		return emptyMsgRef, emptyDMsg, fmt.Errorf("ssb Verify: has no content (%d)", n)
-	} else if runeLength(string(dmsg.Content)) > 8192 {
-		return emptyMsgRef, emptyDMsg, fmt.Errorf("ssb Verify: message too large (%d)", n)
+	contentLengthInRunes := utf8.RuneCount(dmsg.Content)
+
+	if contentLengthInRunes < 1 {
+		return emptyMsgRef, emptyDMsg, fmt.Errorf("ssb Verify: has no content (%d)", contentLengthInRunes)
+	}
+
+	if contentLengthInRunes > 8192 {
+		return emptyMsgRef, emptyDMsg, fmt.Errorf("ssb Verify: message too large (%d)", contentLengthInRunes)
 	}
 
 	// some type consistency checks

--- a/message/legacy/verify.go
+++ b/message/legacy/verify.go
@@ -40,8 +40,7 @@ type DeserializedMessage struct {
 // At last it uses internalV8Binary to create a the SHA256 hash for the message key.
 // If you find a buggy message, use `node ./encode_test.js $feedID` to generate a new testdata.zip
 func Verify(raw []byte, hmacSecret *[32]byte) (refs.MessageRef, DeserializedMessage, error) {
-	var buf bytes.Buffer
-	return VerifyWithBuffer(raw, hmacSecret, &buf)
+	return VerifyWithBuffer(raw, hmacSecret, nil)
 }
 
 var (


### PR DESCRIPTION
Environment:

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 7 3700X 8-Core Processor 
```

Results from `master`:
```
BenchmarkVerify-16    	     633	  18817784 ns/op	 5285065 B/op	   23057 allocs/op
```
Results from this pull request:

```
BenchmarkVerify-16    	     694	  16936649 ns/op	 2035855 B/op	   17710 allocs/op
```

This pull request further reduces the execution time to 90% of what it is on `master` and number of allocs to 77% of what it is on `master`. 